### PR TITLE
Auto-improvements (staging)

### DIFF
--- a/index.html
+++ b/index.html
@@ -545,7 +545,7 @@
               </style>
               <div class="ccu-wrap">
                 <p class="ccu-eyebrow"><span class="ccu-dot"></span> Live · my Claude Code usage</p>
-                <div class="ccu-r"><button data-r="today">Today</button><button data-r="d7">7 days</button><button data-r="d30" class="on">30 days</button><button data-r="all">All time</button></div>
+                <div class="ccu-r" role="group" aria-label="Usage time range"><button type="button" data-r="today" aria-pressed="false">Today</button><button type="button" data-r="d7" aria-pressed="false">7 days</button><button type="button" data-r="d30" class="on" aria-pressed="true">30 days</button><button type="button" data-r="all" aria-pressed="false">All time</button></div>
                 <div class="ccu-h">
                   <div><div class="ccu-num" id="ccu-m">0</div><div class="ccu-lab">Messages</div><div class="ccu-sub">prompts I've sent</div></div>
                   <div><div class="ccu-num" id="ccu-t">0</div><div class="ccu-lab">Tokens</div><div class="ccu-sub">processed</div></div>
@@ -569,7 +569,7 @@
                   var BY=D.by_day,CUT=D.cutoffs;
                   function rng(r){var o={p:0,a:0,t:0,tr:0,o:0,s:0,days:0};BY.forEach(function(x){if(r==="all"||x.d>=CUT[r]){o.p+=x.p;o.a+=x.a;o.t+=x.t;o.tr+=x.tr;o.o+=x.o;o.s+=x.s;if(x.p||x.t)o.days++;}});return o;}
                   function show(r){var s=rng(r);anim(document.getElementById("ccu-m"),s.p,L);anim(document.getElementById("ccu-t"),s.a,ab);document.getElementById("ccu-turns").textContent=L(s.t);document.getElementById("ccu-tools").textContent=L(s.tr);document.getElementById("ccu-convos").textContent=L(s.s);document.getElementById("ccu-written").textContent=ab(s.o);document.getElementById("ccu-days").textContent=L(s.days);}
-                  Array.prototype.forEach.call(document.querySelectorAll(".ccu-r button"),function(b){b.onclick=function(){Array.prototype.forEach.call(document.querySelectorAll(".ccu-r button"),function(x){x.classList.remove("on");});b.classList.add("on");show(b.dataset.r);};});
+                  Array.prototype.forEach.call(document.querySelectorAll(".ccu-r button"),function(b){b.onclick=function(){Array.prototype.forEach.call(document.querySelectorAll(".ccu-r button"),function(x){x.classList.remove("on");x.setAttribute("aria-pressed","false");});b.classList.add("on");b.setAttribute("aria-pressed","true");show(b.dataset.r);};});
                   document.getElementById("ccu-u").textContent="updated "+D.updated+" · auto-refreshes";
                   document.getElementById("ccu").style.display="";
                   show("d30");

--- a/index.html
+++ b/index.html
@@ -608,7 +608,7 @@
                 <div class="about__container bd-grid">
                     <div class="about__img">
 
-                         <img src="assets/img/about.jpg" alt="Jacob Heifetz-Licht portrait" loading="lazy" decoding="async" class="clickable-img" id="about-photo">
+                         <img src="assets/img/about.jpg" alt="Jacob Heifetz-Licht portrait" width="600" height="600" loading="lazy" decoding="async" class="clickable-img" id="about-photo">
 
                     </div>
                     <div>
@@ -785,7 +785,7 @@
                     </div>
 
                     <div>
-                        <img src="assets/img/skills.jpg" alt="Jacob working with data analytics tools" loading="lazy" decoding="async" class="skills__img" id="skills-photo">
+                        <img src="assets/img/skills.jpg" alt="Jacob working with data analytics tools" width="640" height="426" loading="lazy" decoding="async" class="skills__img" id="skills-photo">
                     </div>
                 </div>
             </section>

--- a/light/index.html
+++ b/light/index.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- No-JS fallback: redirect to the main site even when scripting is disabled (the script below handles the JS path) -->
+    <meta http-equiv="refresh" content="0; url=/">
     <title>Jacob Heifetz-Licht</title>
     <meta name="description" content="Data analytics leader specializing in Python, SQL, Tableau, and automation. Turning complex data into actionable insights.">
     <meta name="keywords" content="analytics manager, data analytics, Python, SQL, Tableau, automation, dashboard design, data visualization, ETL, BigQuery">

--- a/weather/index.html
+++ b/weather/index.html
@@ -183,7 +183,7 @@ body {
     <input type="text" id="cityInput" placeholder="Search city..." value="New York, NY" aria-label="Search for a city">
     <button onclick="fetchWeather()">Search</button>
   </div>
-  <div id="alertsBanner" class="alerts-banner"></div>
+  <div id="alertsBanner" class="alerts-banner" aria-live="polite" aria-atomic="true"></div>
   <div id="content">
     <div class="loading" role="status"><div class="spinner" aria-hidden="true"></div><br>Loading weather data...</div>
   </div>
@@ -358,18 +358,24 @@ function render(w, aqi, geo) {
 
   // Alerts
   const willRain = hourly.some(h => h.pop > 40);
-  let alertHtml = '';
+  let alertClass = '', alertMsg = '';
   if (windSpeed >= 25 || gusts >= 40) {
-    alertHtml = `<div id="alertsBanner" class="alerts-banner warning">⚠️ High wind advisory — gusts up to ${gusts || windSpeed} mph. Secure loose items.</div>`;
+    alertClass = 'warning'; alertMsg = `⚠️ High wind advisory — gusts up to ${gusts || windSpeed} mph. Secure loose items.`;
   } else if (temp <= 20) {
-    alertHtml = `<div id="alertsBanner" class="alerts-banner danger">🥶 Extreme cold — frostbite risk. Layer up and limit exposure.</div>`;
+    alertClass = 'danger'; alertMsg = `🥶 Extreme cold — frostbite risk. Layer up and limit exposure.`;
   } else if (temp >= 95 && humidity >= 60) {
-    alertHtml = `<div id="alertsBanner" class="alerts-banner danger">🔥 Excessive heat + humidity — heat stroke risk. Stay indoors if possible.</div>`;
+    alertClass = 'danger'; alertMsg = `🔥 Excessive heat + humidity — heat stroke risk. Stay indoors if possible.`;
   } else if (willRain) {
     const rainH = hourly.find(h => h.pop > 40);
-    alertHtml = `<div id="alertsBanner" class="alerts-banner info">☂️ Rain likely around ${fmtHour(rainH.time)} — grab an umbrella before heading out.</div>`;
+    alertClass = 'info'; alertMsg = `☂️ Rain likely around ${fmtHour(rainH.time)} — grab an umbrella before heading out.`;
   }
-  document.getElementById('alertsBanner').outerHTML = alertHtml || '<div id="alertsBanner" class="alerts-banner"></div>';
+  // Update the persistent aria-live banner in place (rather than replacing it via outerHTML)
+  // so screen readers announce the alert; clear the inline display the reset path set so the
+  // CSS class controls visibility again.
+  const alertsBanner = document.getElementById('alertsBanner');
+  alertsBanner.className = 'alerts-banner' + (alertClass ? ' ' + alertClass : '');
+  alertsBanner.innerHTML = alertMsg;
+  alertsBanner.style.display = alertClass ? '' : 'none';
 
   // Daily forecast
   const days = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];

--- a/weather/index.html
+++ b/weather/index.html
@@ -156,7 +156,7 @@ body {
 
 .section-title {
   font-size:13px; font-weight:600; text-transform:uppercase;
-  letter-spacing:1px; color:var(--text-dim); margin-bottom:12px;
+  letter-spacing:1px; color:var(--text-dim); margin:0 0 12px;
 }
 
 .loading { text-align:center; padding:60px; color:var(--text-dim); font-size:14px; }
@@ -454,7 +454,7 @@ function render(w, aqi, geo) {
 
   // Hourly rain
   html += `<div class="card">
-    <div class="section-title">☂️ Rain Chance — Next 12h</div>
+    <h2 class="section-title">☂️ Rain Chance — Next 12h</h2>
     <div class="hourly-row">
       ${hourly.map(h => {
         const pop = h.pop;
@@ -470,7 +470,7 @@ function render(w, aqi, geo) {
 
   // 5-day forecast
   html += `<div class="card">
-    <div class="section-title">📅 5-Day Forecast</div>
+    <h2 class="section-title">📅 5-Day Forecast</h2>
     ${dailyRows.map(d => {
       return `<div class="forecast-row">
         <div class="forecast-day">${d.day}</div>

--- a/weather/index.html
+++ b/weather/index.html
@@ -182,7 +182,7 @@ body {
 <body>
 <main class="container">
   <h1 class="visually-hidden">Weather Dashboard</h1>
-  <div class="search-bar">
+  <div class="search-bar" role="search" aria-label="City weather search">
     <input type="text" id="cityInput" placeholder="Search city..." value="New York, NY" aria-label="Search for a city">
     <button onclick="fetchWeather()">Search</button>
   </div>

--- a/weather/index.html
+++ b/weather/index.html
@@ -33,6 +33,9 @@
 <link rel="preconnect" href="https://air-quality-api.open-meteo.com" crossorigin>
 <style>
 :root {
+  /* Dark-only dashboard: tell the browser to render UA chrome (scrollbars, the
+     text caret, form autofill) in dark mode so it matches the dark theme. */
+  color-scheme: dark;
   --bg: #0b1121;
   --card: #111a2e;
   --card-border: #1a2744;


### PR DESCRIPTION
Automated, low-risk improvements to jacobhl.com. Each run makes one small, safe, text-only change. Preview via the diff below or locally (GitHub Pages does not build branch previews). **Do not merge automatically.**

### Checklist
- [ ] `index.html`: add intrinsic `width`/`height` to the About (600×600) and Skills (640×426) images to reserve layout space and prevent cumulative layout shift (CLS). Matches the existing pattern already used on the header image; the global `img { max-width:100%; height:auto }` rule keeps responsive scaling intact (no distortion).
- [ ] `weather/index.html`: make the safety-alert banner a screen-reader live region. The weather alerts (high wind, extreme cold, heat stroke, rain) were injected via `outerHTML`, which destroyed the `#alertsBanner` element on every render and left it with no live-region semantics — so assistive tech never announced them. Banner is now a persistent `aria-live="polite"` / `aria-atomic="true"` region updated in place (class + text), so alerts are announced. No visual change.
- [ ] `weather/index.html`: declare `color-scheme: dark` on `:root`. The dashboard is a fully dark-themed page, but without this declaration browsers render UA-styled chrome (scrollbars, the text-input caret, form autofill backgrounds, default focus rings) in light mode, which clashes with the dark design. One CSS line aligns that chrome with the existing theme — no visual change to the authored design.
- [ ] `index.html`: make the "Live · Claude Code usage" time-range toggle (Today / 7 days / 30 days / All time) accessible. The button group had no `aria-pressed` state, so assistive tech couldn't tell which range was selected, and the buttons lacked an explicit `type`. Added `role="group"` + `aria-label` on the container, `type="button"` + `aria-pressed` on each button, and updated the click handler to sync `aria-pressed` alongside the existing `.on` class — mirroring the established view-pill pattern. No visual change.
- [ ] `weather/index.html`: expose the city search as an ARIA `search` landmark. The search bar was a plain container, and the weather page has no `nav`/`header` landmarks, so assistive-tech users had no landmark to jump to the primary control. Added `role="search"` + `aria-label` to the container so it's reachable via landmark navigation. No visual change.
- [ ] `light/index.html`: add a no-JS `<meta http-equiv="refresh">` fallback to the `/light` redirect page. The page previously redirected *only* via JavaScript (`window.location.replace('/')`), so visitors with scripting disabled landed on a stalled "Redirecting…" line and had to click the link manually. The meta-refresh performs the redirect without JS; the existing inline script still runs first for JS users (setting the saved light theme), and the clickable link remains as a final fallback. Two-line, text-only change.
- [ ] `weather/index.html`: promote the two rendered section labels ("Rain Chance — Next 12h", "5-Day Forecast") from `<div class="section-title">` to `<h2 class="section-title">`. The dashboard had only a single visually-hidden `<h1>`, so screen-reader users navigating by heading found no sub-section structure. These labels already read as headings visually (uppercase, weighted), so promoting them to `<h2>` gives proper heading navigation under the `<h1>`. The `.section-title` rule's `margin-bottom:12px` was changed to the `margin:0 0 12px` shorthand to zero out the browser's default `<h2>` top margin, so the rendered layout is pixel-identical. No visual change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQMgvgKrskp8LSVirmPpPs)_