### PR TITLE
Auto-improvements (staging)

### DIFF
--- a/404.html
+++ b/404.html
@@ -19,6 +19,7 @@
             } catch (e) {}
         </script>
         <title>Page Not Found — Jacob Heifetz-Licht</title>
+        <meta name="description" content="The page you're looking for doesn't exist or has been moved. Head back to jacobhl.com — the portfolio of Jacob Heifetz-Licht, analytics manager and web developer.">
         <style>
             .error-page {
                 display: flex;

--- a/404.html
+++ b/404.html
@@ -82,7 +82,7 @@
                     <button id="theme-toggle" class="theme-toggle" aria-label="Switch to light mode" style="position: relative; top: -2px;">
                         <i class='bx bx-sun' id="theme-icon" aria-hidden="true"></i>
                     </button>
-                    <div class="nav__toggle" id="nav-toggle" role="button" aria-label="Toggle navigation menu">
+                    <div class="nav__toggle" id="nav-toggle" role="button" aria-label="Toggle navigation menu" aria-controls="nav-menu">
                         <i class='bx bx-menu' aria-hidden="true"></i>
                     </div>
                 </div>

--- a/404.html
+++ b/404.html
@@ -15,6 +15,10 @@
             try {
                 if (localStorage.getItem('theme') === 'light') {
                     document.documentElement.removeAttribute('data-theme');
+                    // Sync the mobile address-bar colour to the light header before first paint
+                    // (main.js does this too, but only later at the end of <body>).
+                    var tc = document.querySelector('meta[name="theme-color"]');
+                    if (tc) tc.setAttribute('content', '#ffffff');
                 }
             } catch (e) {}
         </script>

--- a/404.html
+++ b/404.html
@@ -104,7 +104,7 @@
             <div class="footer__social">
                 <a href="https://www.linkedin.com/in/jacobhl/" class="footer__icon" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn profile"><i class='bx bxl-linkedin' aria-hidden="true"></i></a>
                 <a href="https://github.com/jacobhl3ca" class="footer__icon" target="_blank" rel="noopener noreferrer" aria-label="GitHub profile"><i class='bx bxl-github' aria-hidden="true"></i></a>
-                <a href="#" onclick="window.location='mail'+'to:'+'hi'+'@'+'jacobhl'+'.com';return false;" class="footer__icon" aria-label="Send email"><i class='bx bx-envelope' aria-hidden="true"></i></a>
+                <a href="mailto:hi@jacobhl.com" class="footer__icon" aria-label="Send email"><i class='bx bx-envelope' aria-hidden="true"></i></a>
                 <a href="/#contact" class="footer__icon" aria-label="Contact"><i class='bx bx-file' aria-hidden="true"></i></a>
             </div>
             <p class="footer__copy">Let's get you back!</p>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -471,6 +471,9 @@ function setupAutoFire(el) {
     }
 
     function startAutoFire(e) {
+        // Honor prefers-reduced-motion: the confetti/burst/mega-explosion effects run via the
+        // Web Animations API, which the site's reduced-motion CSS can't disable, so gate them here.
+        if (prefersReducedMotion()) return;
         e.preventDefault();
         e.stopPropagation();
         if (autoFireTimer) return;
@@ -611,6 +614,9 @@ function handleSkillsClick(e) {
     }
 
     function startAutoFire(e) {
+        // Honor prefers-reduced-motion: the code-snippet popups float in via JS animation, which
+        // the site's reduced-motion CSS can't disable, so gate the effect here.
+        if (prefersReducedMotion()) return;
         e.preventDefault();
         e.stopPropagation();
         if (autoFireTimer) return;

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
         <link rel="stylesheet" href="assets/css/styles.css">
         <link rel="icon" type="image/x-icon" href="assets/img/favicon.ico">
         <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin> <!-- early-connect to the boxicons CDN (CSS + icon font) -->
+        <link rel="dns-prefetch" href="//gc.zgo.at"> <!-- resolve the GoatCounter analytics host ahead of the async count.js fetch at end of body -->
         <link href='https://cdn.jsdelivr.net/npm/boxicons@2.0.5/css/boxicons.min.css' rel='stylesheet'> <!-- icons -->
         <script>
             // Default view = projects-only (set before paint to avoid flash); honor saved preference.

--- a/index.html
+++ b/index.html
@@ -22,6 +22,10 @@
                 }
                 if (localStorage.getItem('theme') === 'light') {
                     document.documentElement.removeAttribute('data-theme');
+                    // Sync the mobile address-bar colour to the light header before first paint
+                    // (main.js does this too, but only later at the end of <body>).
+                    var tc = document.querySelector('meta[name="theme-color"]');
+                    if (tc) tc.setAttribute('content', '#ffffff');
                 }
             } catch (e) {
                 document.documentElement.classList.add('projects-only');

--- a/index.html
+++ b/index.html
@@ -664,6 +664,18 @@
 
                 <div class="proj-wrap">
                     <div id="main-rows"></div>
+                    <noscript>
+                        <!-- The project cards above are built by JavaScript, so with scripting disabled
+                             (or for crawlers that don't run JS) #main-rows is empty. List the live
+                             projects as plain links so the core content and its SEO value aren't lost. -->
+                        <ul style="list-style:none;margin:0;padding:0;line-height:1.6;color:var(--text-color,#8b94a0);">
+                            <li><a href="https://hidescore.com" target="_blank" rel="noopener noreferrer">HideScore</a> — Watch sports highlights without seeing the score.</li>
+                            <li><a href="https://tonightnyc.com" target="_blank" rel="noopener noreferrer">Tonight NYC</a> — Every NYC comedy show, filtered to your favorite comedians.</li>
+                            <li><a href="https://subwaytimes.com" target="_blank" rel="noopener noreferrer">Subway Times</a> — Real-time NYC subway arrivals, faster than Maps.</li>
+                            <li><a href="https://davidlicht.com" target="_blank" rel="noopener noreferrer">David Licht</a> — A showcase site for my dad — five decades of drumming.</li>
+                            <li><a href="https://theisland.nyc" target="_blank" rel="noopener noreferrer">The Island</a> — Everything happening on NYC's Roosevelt Island, in one place.</li>
+                        </ul>
+                    </noscript>
 
                     <button class="more-toggle" id="moreToggle" aria-expanded="false" aria-controls="moreWrap">
                         <span id="moreLabel">Private projects</span>

--- a/index.html
+++ b/index.html
@@ -714,7 +714,7 @@
                         END V2 -->
 
                         <div class="skills__category">
-                            <h3 class="skills__category-title"><i class='bx bx-code-alt skills__icon' aria-hidden="true"></i> Languages & Scripting</h3>
+                            <h4 class="skills__category-title"><i class='bx bx-code-alt skills__icon' aria-hidden="true"></i> Languages & Scripting</h4>
                             <div class="skills__tags">
                                 <span class="skills__tag">Python</span>
                                 <span class="skills__tag">SQL</span>
@@ -737,7 +737,7 @@
                         -->
 
                         <div class="skills__category">
-                            <h3 class="skills__category-title"><i class='bx bx-bar-chart-alt-2 skills__icon' aria-hidden="true"></i> Data & Visualization</h3>
+                            <h4 class="skills__category-title"><i class='bx bx-bar-chart-alt-2 skills__icon' aria-hidden="true"></i> Data & Visualization</h4>
                             <div class="skills__tags">
                                 <span class="skills__tag">Tableau</span>
                                 <span class="skills__tag">Looker</span>
@@ -750,7 +750,7 @@
                         </div>
 
                         <div class="skills__category">
-                            <h3 class="skills__category-title"><i class='bx bx-data skills__icon' aria-hidden="true"></i> Analytics Platforms</h3>
+                            <h4 class="skills__category-title"><i class='bx bx-data skills__icon' aria-hidden="true"></i> Analytics Platforms</h4>
                             <div class="skills__tags">
                                 <span class="skills__tag">BigQuery</span>
                                 <span class="skills__tag">GA4</span>
@@ -760,7 +760,7 @@
                         </div>
 
                         <div class="skills__category">
-                            <h3 class="skills__category-title"><i class='bx bx-cog skills__icon' aria-hidden="true"></i> Automation & Infrastructure</h3>
+                            <h4 class="skills__category-title"><i class='bx bx-cog skills__icon' aria-hidden="true"></i> Automation & Infrastructure</h4>
                             <div class="skills__tags">
                                 <span class="skills__tag">Process Automation</span>
                                 <span class="skills__tag">ETL Pipelines</span>
@@ -772,7 +772,7 @@
                         </div>
 
                         <div class="skills__category">
-                            <h3 class="skills__category-title"><i class='bx bx-bulb skills__icon' aria-hidden="true"></i> Strategy & Leadership</h3>
+                            <h4 class="skills__category-title"><i class='bx bx-bulb skills__icon' aria-hidden="true"></i> Strategy & Leadership</h4>
                             <div class="skills__tags">
                                 <span class="skills__tag">Analytics Strategy</span>
                                 <span class="skills__tag">Stakeholder Communication</span>

--- a/index.html
+++ b/index.html
@@ -807,6 +807,8 @@
                 <h2 class="section-title" id="contact-heading">Contact</h2>
                 <div class="contact__container bd-grid">
                     <form action="https://formspree.io/f/mkgqkgyr" method="POST" class="contact__form">
+                        <!-- Formspree honeypot: hidden from people, but bots fill it in — those submissions are silently discarded as spam. Kept out of the tab order and the accessibility tree. -->
+                        <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" aria-hidden="true" style="position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;">
                         <input type="text" name="name" placeholder="Your Name" class="contact__input" aria-label="Your name" autocomplete="name" required>
                         <input type="email" name="email" placeholder="your@email.com" class="contact__input" aria-label="Your email address" autocomplete="email" required>
                         <textarea name="message" placeholder="Your Message" class="contact__input" aria-label="Your message" rows="10" required></textarea>

--- a/index.html
+++ b/index.html
@@ -513,7 +513,7 @@
                     <button id="theme-toggle" class="theme-toggle" aria-label="Switch to light mode" style="position: relative; top: 0;">
                         <i class='bx bx-sun' id="theme-icon" aria-hidden="true"></i>
                     </button>
-                    <div class="nav__toggle" id="nav-toggle" role="button" aria-label="Toggle navigation menu">
+                    <div class="nav__toggle" id="nav-toggle" role="button" aria-label="Toggle navigation menu" aria-controls="nav-menu">
                         <i class='bx bx-menu' aria-hidden="true"></i>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
         <link rel="stylesheet" href="assets/css/styles.css">
         <link rel="icon" type="image/x-icon" href="assets/img/favicon.ico">
         <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin> <!-- early-connect to the boxicons CDN (CSS + icon font) -->
+        <link rel="preconnect" href="https://fonts.googleapis.com"> <!-- early-connect to Google Fonts CSS (styles.css @imports Poppins from here, on the critical path) -->
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin> <!-- early-connect to the Google Fonts file host; crossorigin so the warmed socket is reused for the CORS woff2 fetch -->
         <link rel="dns-prefetch" href="//gc.zgo.at"> <!-- resolve the GoatCounter analytics host ahead of the async count.js fetch at end of body -->
         <link rel="dns-prefetch" href="//stats.hidescore.com"> <!-- resolve the self-hosted Umami analytics host ahead of its deferred script.js fetch at end of body -->
         <link href='https://cdn.jsdelivr.net/npm/boxicons@2.0.5/css/boxicons.min.css' rel='stylesheet'> <!-- icons -->

--- a/index.html
+++ b/index.html
@@ -1005,7 +1005,10 @@ document.querySelectorAll('.proj-head').forEach(h=>{
     if(e.target.closest('a')) return;                     // let the site / App Store links work
     const open = h.closest('.proj-row').classList.toggle('open');
     const chev = h.querySelector('.proj-chev');
-    if(chev) chev.setAttribute('aria-expanded', open); // mirror collapsed/expanded state to assistive tech
+    if(chev){
+      chev.setAttribute('aria-expanded', open); // mirror collapsed/expanded state to assistive tech
+      chev.setAttribute('aria-label', open ? 'Hide details' : 'Show details'); // keep the action label in sync with the state
+    }
   });
 });
 

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
         <meta property="og:image:width" content="1200">
         <meta property="og:image:height" content="630">
         <meta property="og:image:alt" content="Jacob Heifetz-Licht — Analytics Manager and web developer">
-        <meta property="og:url" content="https://jacobhl.com">
+        <meta property="og:url" content="https://jacobhl.com/">
         <meta property="og:type" content="website">
         <meta property="og:site_name" content="Jacob Heifetz-Licht">
         <meta property="og:locale" content="en_US">
@@ -54,13 +54,13 @@
         <meta name="twitter:description" content="Data analytics leader and web developer specializing in Python, SQL, Tableau, React, and Next.js. Turning data into things people actually use.">
         <meta name="twitter:image" content="https://jacobhl.com/assets/img/og_image.png">
         <meta name="twitter:image:alt" content="Jacob Heifetz-Licht — Analytics Manager and web developer">
-        <link rel="canonical" href="https://jacobhl.com">
+        <link rel="canonical" href="https://jacobhl.com/">
         <script type="application/ld+json">
         {
             "@context": "https://schema.org",
             "@type": "Person",
             "name": "Jacob Heifetz-Licht",
-            "url": "https://jacobhl.com",
+            "url": "https://jacobhl.com/",
             "image": "https://jacobhl.com/assets/img/about.jpg",
             "jobTitle": "Analytics Manager",
             "description": "Data analytics leader and web developer specializing in Python, SQL, Tableau, React, and Next.js.",

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
         <link rel="icon" type="image/x-icon" href="assets/img/favicon.ico">
         <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin> <!-- early-connect to the boxicons CDN (CSS + icon font) -->
         <link rel="dns-prefetch" href="//gc.zgo.at"> <!-- resolve the GoatCounter analytics host ahead of the async count.js fetch at end of body -->
+        <link rel="dns-prefetch" href="//stats.hidescore.com"> <!-- resolve the self-hosted Umami analytics host ahead of its deferred script.js fetch at end of body -->
         <link href='https://cdn.jsdelivr.net/npm/boxicons@2.0.5/css/boxicons.min.css' rel='stylesheet'> <!-- icons -->
         <script>
             // Default view = projects-only (set before paint to avoid flash); honor saved preference.

--- a/light/index.html
+++ b/light/index.html
@@ -13,12 +13,17 @@
     <meta property="og:title" content="Jacob Heifetz-Licht — Analytics Manager">
     <meta property="og:description" content="Data analytics leader specializing in Python, SQL, Tableau, and automation. Turning complex data into actionable insights.">
     <meta property="og:image" content="https://jacobhl.com/assets/img/og_image_centered.png">
+    <meta property="og:image:type" content="image/png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Jacob Heifetz-Licht — Analytics Manager and web developer">
     <meta property="og:url" content="https://jacobhl.com/light">
     <meta property="og:type" content="website">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="Jacob Heifetz-Licht — Analytics Manager">
     <meta name="twitter:description" content="Data analytics leader specializing in Python, SQL, Tableau, and automation. Turning complex data into actionable insights.">
     <meta name="twitter:image" content="https://jacobhl.com/assets/img/og_image_centered.png">
+    <meta name="twitter:image:alt" content="Jacob Heifetz-Licht — Analytics Manager and web developer">
     <script>
         // Force light mode and redirect to main site.
         // Guard localStorage (it can throw in private mode / when storage is blocked)

--- a/weather/index.html
+++ b/weather/index.html
@@ -486,7 +486,7 @@ function render(w, aqi, geo) {
 
   // Hourly rain
   html += `<div class="card">
-    <h2 class="section-title">☂️ Rain Chance — Next 12h</h2>
+    <h2 class="section-title"><span aria-hidden="true">☂️</span> Rain Chance — Next 12h</h2>
     <div class="hourly-row">
       ${hourly.map(h => {
         const pop = h.pop;
@@ -502,7 +502,7 @@ function render(w, aqi, geo) {
 
   // 5-day forecast
   html += `<div class="card">
-    <h2 class="section-title">📅 5-Day Forecast</h2>
+    <h2 class="section-title"><span aria-hidden="true">📅</span> 5-Day Forecast</h2>
     ${dailyRows.map(d => {
       return `<div class="forecast-row">
         <div class="forecast-day">${d.day}</div>

--- a/weather/index.html
+++ b/weather/index.html
@@ -8,6 +8,25 @@
 <title>Weather Dashboard — NYC</title>
 <meta name="description" content="A live weather dashboard with current conditions, hourly rain chance, a 5-day forecast, air quality, and sun times. Search any city — defaults to New York, NY.">
 <link rel="canonical" href="https://jacobhl.com/weather/">
+<!-- Structured data so search engines understand this is a free, browser-based weather app (mirrors the Person schema on the main site) -->
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "Weather Dashboard",
+    "url": "https://jacobhl.com/weather/",
+    "description": "A live weather dashboard with current conditions, hourly rain chance, a 5-day forecast, air quality, and sun times. Search any city — defaults to New York, NY.",
+    "applicationCategory": "UtilitiesApplication",
+    "operatingSystem": "Web browser",
+    "browserRequirements": "Requires JavaScript",
+    "isAccessibleForFree": true,
+    "author": {
+        "@type": "Person",
+        "name": "Jacob Heifetz-Licht",
+        "url": "https://jacobhl.com"
+    }
+}
+</script>
 <!-- Open Graph / Twitter meta for link previews -->
 <meta property="og:title" content="Weather Dashboard">
 <meta property="og:description" content="A live weather dashboard with current conditions, hourly rain chance, a 5-day forecast, air quality, and sun times. Search any city — defaults to New York, NY.">

--- a/weather/index.html
+++ b/weather/index.html
@@ -395,14 +395,14 @@ function render(w, aqi, geo) {
   const willRain = hourly.some(h => h.pop > 40);
   let alertClass = '', alertMsg = '';
   if (windSpeed >= 25 || gusts >= 40) {
-    alertClass = 'warning'; alertMsg = `⚠️ High wind advisory — gusts up to ${gusts || windSpeed} mph. Secure loose items.`;
+    alertClass = 'warning'; alertMsg = `<span aria-hidden="true">⚠️</span> High wind advisory — gusts up to ${gusts || windSpeed} mph. Secure loose items.`;
   } else if (temp <= 20) {
-    alertClass = 'danger'; alertMsg = `🥶 Extreme cold — frostbite risk. Layer up and limit exposure.`;
+    alertClass = 'danger'; alertMsg = `<span aria-hidden="true">🥶</span> Extreme cold — frostbite risk. Layer up and limit exposure.`;
   } else if (temp >= 95 && humidity >= 60) {
-    alertClass = 'danger'; alertMsg = `🔥 Excessive heat + humidity — heat stroke risk. Stay indoors if possible.`;
+    alertClass = 'danger'; alertMsg = `<span aria-hidden="true">🔥</span> Excessive heat + humidity — heat stroke risk. Stay indoors if possible.`;
   } else if (willRain) {
     const rainH = hourly.find(h => h.pop > 40);
-    alertClass = 'info'; alertMsg = `☂️ Rain likely around ${fmtHour(rainH.time)} — grab an umbrella before heading out.`;
+    alertClass = 'info'; alertMsg = `<span aria-hidden="true">☂️</span> Rain likely around ${fmtHour(rainH.time)} — grab an umbrella before heading out.`;
   }
   // Update the persistent aria-live banner in place (rather than replacing it via outerHTML)
   // so screen readers announce the alert; clear the inline display the reset path set so the
@@ -516,10 +516,10 @@ function render(w, aqi, geo) {
   // NYC tip
   html += `<div class="card" style="text-align:center;">
     <div style="font-size:12px;color:var(--text-dim);">
-      ${temp <= 35 ? '🧤 NYC Tip: Watch for icy sidewalks, especially bridge overpasses and shaded blocks.' :
-        temp >= 90 ? '🚰 NYC Tip: Cooling centers are open. Stay near AC — check NYC.gov for locations.' :
-        willRain ? '🚇 NYC Tip: Expect crowded subways. Leave 10 min early and bring an umbrella.' :
-        '🏙️ NYC Tip: Great day to walk — Central Park and the High Line are calling.'}
+      ${temp <= 35 ? '<span aria-hidden="true">🧤</span> NYC Tip: Watch for icy sidewalks, especially bridge overpasses and shaded blocks.' :
+        temp >= 90 ? '<span aria-hidden="true">🚰</span> NYC Tip: Cooling centers are open. Stay near AC — check NYC.gov for locations.' :
+        willRain ? '<span aria-hidden="true">🚇</span> NYC Tip: Expect crowded subways. Leave 10 min early and bring an umbrella.' :
+        '<span aria-hidden="true">🏙️</span> NYC Tip: Great day to walk — Central Park and the High Line are calling.'}
     </div>
   </div>`;
 

--- a/weather/index.html
+++ b/weather/index.html
@@ -204,7 +204,7 @@ body {
   <h1 class="visually-hidden">Weather Dashboard</h1>
   <div class="search-bar" role="search" aria-label="City weather search">
     <input type="text" id="cityInput" placeholder="Search city..." value="New York, NY" aria-label="Search for a city" enterkeyhint="search" autocapitalize="words" autocorrect="off" spellcheck="false">
-    <button onclick="fetchWeather()">Search</button>
+    <button type="button" onclick="fetchWeather()">Search</button>
   </div>
   <div id="alertsBanner" class="alerts-banner" aria-live="polite" aria-atomic="true"></div>
   <!-- Persistent polite live region: the loading spinner (role=status) is wiped when results

--- a/weather/index.html
+++ b/weather/index.html
@@ -532,5 +532,9 @@ document.getElementById('cityInput').addEventListener('keydown', e => {
 
 fetchWeather();
 </script>
+
+<!-- GoatCounter analytics — same as the homepage and 404 page, so weather dashboard visits are counted too -->
+<script data-goatcounter="https://jacobhl.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>

--- a/weather/index.html
+++ b/weather/index.html
@@ -207,6 +207,9 @@ body {
     <button onclick="fetchWeather()">Search</button>
   </div>
   <div id="alertsBanner" class="alerts-banner" aria-live="polite" aria-atomic="true"></div>
+  <!-- Persistent polite live region: the loading spinner (role=status) is wiped when results
+       render, so screen-reader users otherwise get no confirmation the new city's weather arrived. -->
+  <div id="srStatus" class="visually-hidden" role="status" aria-live="polite"></div>
   <div id="content">
     <div class="loading" role="status"><div class="spinner" aria-hidden="true"></div><br>Loading weather data...</div>
     <noscript>
@@ -334,6 +337,9 @@ async function fetchWeather() {
 function render(w, aqi, geo) {
   // Reflect the loaded city in the tab title (the static <title> only says NYC).
   if (geo && geo.name) document.title = `${geo.name} — Weather Dashboard`;
+  // Announce completion to screen readers (the loading status node is replaced below).
+  const srStatus = document.getElementById('srStatus');
+  if (srStatus) srStatus.textContent = `Weather for ${geo && geo.name ? geo.name : 'your location'} loaded.`;
   const c = w.current;
   const temp = Math.round(c.temperature_2m);
   const feelsLike = Math.round(c.apparent_temperature);

--- a/weather/index.html
+++ b/weather/index.html
@@ -28,7 +28,7 @@
 }
 </script>
 <!-- Open Graph / Twitter meta for link previews -->
-<meta property="og:title" content="Weather Dashboard">
+<meta property="og:title" content="Weather Dashboard — NYC">
 <meta property="og:description" content="A live weather dashboard with current conditions, hourly rain chance, a 5-day forecast, air quality, and sun times. Search any city — defaults to New York, NY.">
 <meta property="og:image" content="https://jacobhl.com/assets/img/og_image.png">
 <meta property="og:image:type" content="image/png">
@@ -40,7 +40,7 @@
 <meta property="og:site_name" content="Jacob Heifetz-Licht">
 <meta property="og:locale" content="en_US">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Weather Dashboard">
+<meta name="twitter:title" content="Weather Dashboard — NYC">
 <meta name="twitter:description" content="A live weather dashboard with current conditions, hourly rain chance, a 5-day forecast, air quality, and sun times. Search any city — defaults to New York, NY.">
 <meta name="twitter:image" content="https://jacobhl.com/assets/img/og_image.png">
 <meta name="twitter:image:alt" content="Jacob Heifetz-Licht — portfolio link preview">

--- a/weather/index.html
+++ b/weather/index.html
@@ -192,6 +192,11 @@ body {
 .aqi-bar { display:flex; height:8px; border-radius:4px; overflow:hidden; margin-top:8px; gap:2px; }
 .aqi-seg { flex:1; border-radius:4px; }
 
+/* Data-source attribution: Open-Meteo's free API data is licensed CC BY 4.0, which requires credit. */
+.attribution { text-align:center; margin-top:32px; padding-bottom:24px; color:var(--text-dim); font-size:12px; }
+.attribution a { color:var(--accent); text-decoration:none; }
+.attribution a:hover { text-decoration:underline; }
+
 /* Visually hidden but available to assistive tech (gives the page a programmatic heading) */
 .visually-hidden {
   position:absolute; width:1px; height:1px; padding:0; margin:-1px;
@@ -220,6 +225,11 @@ body {
     </noscript>
   </div>
 </main>
+
+<!-- Open-Meteo requires attribution: its weather/air-quality data is published under CC BY 4.0. -->
+<footer class="attribution">
+  Weather &amp; air-quality data by <a href="https://open-meteo.com/" target="_blank" rel="noopener">Open-Meteo.com</a> (CC&nbsp;BY&nbsp;4.0)
+</footer>
 
 <script>
 const WMO_ICONS = {

--- a/weather/index.html
+++ b/weather/index.html
@@ -12,6 +12,7 @@
 <meta property="og:title" content="Weather Dashboard">
 <meta property="og:description" content="A live weather dashboard with current conditions, hourly rain chance, a 5-day forecast, air quality, and sun times. Search any city — defaults to New York, NY.">
 <meta property="og:image" content="https://jacobhl.com/assets/img/og_image.png">
+<meta property="og:image:type" content="image/png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:image:alt" content="Jacob Heifetz-Licht — portfolio link preview">


### PR DESCRIPTION
Automated, low-risk improvements to jacobhl.com. Each run makes one small, safe, text-only change on `auto/staging`. Review the diff and merge when you're happy — nothing here is merged or deployed automatically.

### Run checklist
- [x] `weather/index.html`: add `og:image:type` (`image/png`) so the Open Graph image metadata is complete, matching the homepage.
- [x] `weather/index.html`: add `WebApplication` JSON-LD structured data (name, description, category, author) so search engines understand the dashboard as a free browser app — mirrors the `Person` schema on the homepage.
- [x] `assets/js/main.js`: honor `prefers-reduced-motion` for the JS image click-effects (confetti, bursts, full-screen mega-explosion + flash, skills code-snippet popups), which run via the Web Animations API and the reduced-motion CSS can't disable.
- [x] `404.html`: add a meta description tag — it was the only page missing one (homepage, weather dashboard, and `/light` all have descriptions), now consistent.
- [x] `weather/index.html`: add a persistent polite `role="status"` live region announcing "Weather for {city} loaded." on each successful render, so screen-reader users get confirmation the new city's data arrived.
- [x] `index.html`, `404.html`: link the nav hamburger to its menu via `aria-controls`.
- [x] `index.html`: add a noscript fallback listing the live projects, since the core projects section is JS-rendered and otherwise empty for crawlers / no-JS visitors.
- [x] `index.html`: add a Formspree `_gotcha` honeypot to the contact form to cut spam.
- [x] `weather/index.html`: add GoatCounter analytics so dashboard visits are counted (matching `index.html` and `404.html`).
- [x] `404.html`: use a plain `mailto:` for the footer email link so it works without JS (matches the homepage footer).
- [x] `index.html`: dns-prefetch the GoatCounter analytics host so the async `count.js` connection sets up faster.
- [x] `index.html`: dns-prefetch the self-hosted Umami analytics host (`stats.hidescore.com`) so its deferred `script.js` connects faster, mirroring the existing GoatCounter hint.
- [x] `index.html`: toggle the project card chevron's `aria-label` to "Hide details" when the card is expanded (was always "Show details"), so its announced label matches its `aria-expanded` state — consistent with the "Private projects" toggle's label swap.
- [x] `light/index.html`: complete the Open Graph / Twitter image metadata (`og:image:type`, `og:image:width` 1200, `og:image:height` 630, `og:image:alt`, `twitter:image:alt`) so the `/light` page's link previews are accessible and consistent with `index.html` and `weather/` — it was the last page missing image dimensions/alt.
- [x] `weather/index.html`: set an explicit `type="button"` on the dashboard's Search button so it can never act as an implicit form submit (untyped defaults to `type="submit"`) — a defensive correctness fix with no visual change.
- [x] `index.html`: nest the Skills category headings (Languages & Scripting, Data & Visualization, Analytics Platforms, Automation & Infrastructure, Strategy & Leadership) as `<h4>` under the "Professional Skills" `<h3>`, fixing the heading outline (h1 → h2 → h3 → h4) for screen-reader navigation. Styling is by class, so no visual change.
- [x] `index.html`: preconnect to the Google Fonts hosts (`fonts.googleapis.com`, and `fonts.gstatic.com` with `crossorigin`). The Poppins font is pulled via a CSS `@import` in `styles.css`, so its connection setup otherwise starts late, on the critical render path. Warming both sockets early shaves connection latency off the font load. No visual change.
- [x] `index.html`: sync the `theme-color` meta to the light header colour (`#ffffff`) inside the existing "before first paint" inline head script, so light-mode visitors don't briefly see the dark mobile address bar on load. No visual change to the page body.
- [x] `404.html`: apply the same pre-paint `theme-color` sync as the homepage — the 404 page's inline head script already removes `data-theme` for light-mode users before paint, but left the mobile address-bar colour dark (`#090f20`) until `main.js` ran at the end of body. Now light-mode visitors who hit a 404 don't briefly see the dark address bar. No visual change to the page body; mirrors `setThemeColor()` in `main.js`.
- [x] `weather/index.html`: wrap the leading decorative emoji (☂️ Rain Chance, 📅 5-Day Forecast) in the two `<h2>` headings, so screen readers announce the heading text without first reading the emoji name. Matches how every other decorative emoji/icon on the page is already marked. No visual change.
- [x] `weather/index.html`: aria-hide the leading decorative emoji in the alert banner (⚠️/🥶/🔥/☂️) and the NYC tip card (🧤/🚰/🚇/🏙️). The following text already conveys the meaning, so the emoji are decorative — wrapping each keeps screen readers from announcing them by name, consistent with the section-title and stat-icon treatment. No visual change.
- [x] `weather/index.html`: add a small data-source attribution footer ("Weather & air-quality data by Open-Meteo.com (CC BY 4.0)") — Open-Meteo's free API publishes its data under CC BY 4.0, which requires credit. Styled with the existing dark-theme vars (dim text, accent link), so it blends in with no design change.
- [x] `weather/index.html`: align the `og:title` and `twitter:title` with the page `<title>` ("Weather Dashboard — NYC") for consistent link previews.
- [x] `index.html`: use the trailing-slash homepage URL (`https://jacobhl.com/`) in the `canonical` link, `og:url`, and Person JSON-LD `url`, so the homepage's self-referencing canonical matches `sitemap.xml` and the site's existing `/weather/` trailing-slash convention — consistent canonicalization signals for search engines. No visual change.