### PR TITLE
Auto-improvements (staging)

### DIFF
--- a/404.html
+++ b/404.html
@@ -107,6 +107,25 @@
                     <button id="theme-toggle" class="theme-toggle" aria-label="Switch to light mode" style="position: relative; top: -2px;">
                         <i class='bx bx-sun' id="theme-icon" aria-hidden="true"></i>
                     </button>
+                    <script>
+                        // Correct the theme toggle's baseline state for returning light-mode users,
+                        // before paint and before main.js loads at end of <body>. The button is hardcoded
+                        // in its dark-mode state (sun icon + "Switch to light mode"), but the inline <head>
+                        // script has already applied the saved light theme — so without this the toggle
+                        // briefly shows the wrong icon and, more importantly, announces the wrong action to
+                        // assistive tech ("Switch to light mode" while the page is already light). main.js
+                        // re-applies the same state later (classList.replace is a no-op when the class is
+                        // absent, and the aria-label is identical), so this only removes the flash/mismatch.
+                        // Mirrors index.html.
+                        try {
+                            if (localStorage.getItem('theme') === 'light') {
+                                var _ti = document.getElementById('theme-icon');
+                                if (_ti) _ti.classList.replace('bx-sun', 'bx-moon');
+                                var _tt = document.getElementById('theme-toggle');
+                                if (_tt) _tt.setAttribute('aria-label', 'Switch to dark mode');
+                            }
+                        } catch (e) {}
+                    </script>
                     <div class="nav__toggle" id="nav-toggle" role="button" tabindex="0" aria-label="Toggle navigation menu" aria-controls="nav-menu" aria-expanded="false"> <!-- baseline tabindex + collapsed state so the toggle is keyboard-focusable and its state is announced before/independent of main.js (mirrors index.html; main.js's guard prevents double-setting) -->
                         <i class='bx bx-menu' aria-hidden="true"></i>
                     </div>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -701,6 +701,19 @@ img {
   outline-offset: 2px;
 }
 
+/* Keyboard focus indicator for the remaining icon controls: the hero social/
+   resume links, the footer social links, and the mobile nav (hamburger) toggle.
+   These were the last interactive elements still falling back to the inconsistent
+   browser-default focus outline while every other element ships the branded accent
+   ring (WCAG 2.4.7 Focus Visible). Scoped to :focus-visible so mouse/touch focus
+   shows no ring (look unchanged). Mirrors the .button / CTA / theme-toggle convention. */
+.home__social-icon:focus-visible,
+.footer__icon:focus-visible,
+.nav__toggle:focus-visible {
+  outline: 2px solid var(--first-color);
+  outline-offset: 2px;
+}
+
 /* ===== ABOUT =====*/
 .about__container {
   row-gap: 2rem;

--- a/index.html
+++ b/index.html
@@ -432,7 +432,6 @@
   [data-theme="dark"] .proj-chev{color:#e0e0e0;}
   .proj-chev i{font-size:1.5rem;line-height:1;transition:transform .25s ease;}
   .proj-chev:hover{color:var(--first-color);border-color:var(--first-color);}
-  [data-theme="dark"] .proj-chev{color:#e0e0e0;}
   .proj-row.open .proj-chev{color:var(--first-color);border-color:var(--first-color);}
   .proj-row.open .proj-chev i{transform:rotate(180deg);}
 

--- a/index.html
+++ b/index.html
@@ -340,6 +340,11 @@
     transition:border-color .2s ease,color .2s ease,transform .2s ease;}
   [data-theme="dark"] .proj-linkedin{color:#e0e0e0;}
   .proj-linkedin:hover{border-color:var(--first-color);color:var(--first-color);transform:translateY(-50%) translateY(-1px);}
+  /* Branded focus ring so keyboard users get the same accent outline as the rest of the site
+     instead of the inconsistent browser default (WCAG 2.4.7). :focus-visible only, so mouse/touch
+     clicks show no ring and the look is unchanged; the outline follows the button's circular shape. */
+  .proj-linkedin:focus{outline:none;}
+  .proj-linkedin:focus-visible{outline:2px solid var(--first-color);outline-offset:2px;}
   .proj-linkedin i{font-size:1.45rem;line-height:1;}
   /* projects-only view starts at this section, just under the fixed header — clear it with a
      small gap. The header is ~48px on narrow widths and 72px on desktop, so match it per-width
@@ -473,6 +478,11 @@
     color:var(--second-color);padding:.65rem 1.5rem;transition:all .25s ease;}
   [data-theme="dark"] .more-toggle{color:#e0e0e0;}
   .more-toggle:hover{color:var(--first-color);border-color:var(--first-color);}
+  /* Branded focus ring to match the rest of the site's controls instead of the browser default
+     (WCAG 2.4.7). :focus-visible only, so mouse/touch focus shows no ring; the outline follows
+     the button's pill radius. */
+  .more-toggle:focus{outline:none;}
+  .more-toggle:focus-visible{outline:2px solid var(--first-color);outline-offset:2px;}
   .more-toggle i{font-size:1.4rem;transition:transform .3s ease;}
   .more-toggle.open i{transform:rotate(180deg);}
   .more-wrap{display:grid;grid-template-rows:0fr;transition:grid-template-rows .35s ease;}

--- a/index.html
+++ b/index.html
@@ -603,6 +603,24 @@
                     <button id="theme-toggle" class="theme-toggle" aria-label="Switch to light mode" style="position: relative; top: 0;">
                         <i class='bx bx-sun' id="theme-icon" aria-hidden="true"></i>
                     </button>
+                    <script>
+                        // Correct the theme toggle's baseline state for returning light-mode users,
+                        // before paint and before main.js loads at end of <body>. The button is hardcoded
+                        // in its dark-mode state (sun icon + "Switch to light mode"), but the inline <head>
+                        // script has already applied the saved light theme — so without this the toggle
+                        // briefly shows the wrong icon and, more importantly, announces the wrong action to
+                        // assistive tech ("Switch to light mode" while the page is already light). main.js
+                        // re-applies the same state later (classList.replace is a no-op when the class is
+                        // absent, and the aria-label is identical), so this only removes the flash/mismatch.
+                        try {
+                            if (localStorage.getItem('theme') === 'light') {
+                                var _ti = document.getElementById('theme-icon');
+                                if (_ti) _ti.classList.replace('bx-sun', 'bx-moon');
+                                var _tt = document.getElementById('theme-toggle');
+                                if (_tt) _tt.setAttribute('aria-label', 'Switch to dark mode');
+                            }
+                        } catch (e) {}
+                    </script>
                     <div class="nav__toggle" id="nav-toggle" role="button" tabindex="0" aria-label="Toggle navigation menu" aria-controls="nav-menu" aria-expanded="false">
                         <i class='bx bx-menu' aria-hidden="true"></i>
                     </div>

--- a/index.html
+++ b/index.html
@@ -584,7 +584,7 @@
                 <div class="nav__menu" id="nav-menu">
                     <ul class="nav__list">
 
-                        <li class="nav__item"><a href="#home" class="nav__link active-link">Home</a></li>
+                        <li class="nav__item"><a href="#home" class="nav__link active-link" aria-current="page">Home</a></li> <!-- baseline aria-current to match the hardcoded active-link class, so AT announces Home as the current section before/independent of main.js's scrollActive() (which manages this pair dynamically thereafter) -->
                         <li class="nav__item"><a href="#about" class="nav__link">About</a></li>
 
                         <!-- Update Periodically -->

--- a/index.html
+++ b/index.html
@@ -544,6 +544,17 @@
   .esc-hint kbd{font:inherit;font-size:.7rem;padding:.05rem .34rem;border-radius:4px;background:#2a3242;color:#fff;}
   .esc-hint:hover{background:rgba(20,24,30,.95);}
   .modal.frame-focused .esc-hint{display:inline-flex;}
+  /* Branded keyboard-focus ring for the live-preview dialog's toolbar controls, matching the accent
+     :focus-visible ring the rest of the site ships (WCAG 2.4.7 Focus Visible). The modal is
+     aria-modal="true", so keyboard users who open a project preview tab straight through these — the
+     traffic-light dots, back/reload, open-in-new-tab and close controls — yet they were the only
+     interactive elements still falling back to the low-contrast browser-default outline against the
+     dark bar. Scoped to :focus-visible so mouse/touch focus shows no ring — the look is unchanged. */
+  .modal-bar .dots .dot:focus,.nav-btn:focus,.modal-bar a.openext:focus,
+  .modal-bar button.mclose:focus,.fs-back:focus,.esc-hint:focus{outline:none;}
+  .modal-bar .dots .dot:focus-visible,.nav-btn:focus-visible,.modal-bar a.openext:focus-visible,
+  .modal-bar button.mclose:focus-visible,.fs-back:focus-visible,.esc-hint:focus-visible{
+    outline:2px solid var(--first-color);outline-offset:2px;}
   .modal-load{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;
     gap:.7rem;background:#0c0e12;color:#9aa3b4;font-size:.85rem;z-index:1;transition:opacity .25s ease;}
   .modal-load.hidden{opacity:0;pointer-events:none;}

--- a/index.html
+++ b/index.html
@@ -844,12 +844,12 @@
                         END V2 -->
 
                         <div class="skills__category">
-                            <h4 class="skills__category-title"><i class='bx bx-code-alt skills__icon' aria-hidden="true"></i> Languages & Scripting</h4>
-                            <div class="skills__tags">
-                                <span class="skills__tag">Python</span>
-                                <span class="skills__tag">SQL</span>
-                                <span class="skills__tag">Google Apps Script</span>
-                                <span class="skills__tag">HTML / CSS</span>
+                            <h4 class="skills__category-title" id="skills-cat-langs"><i class='bx bx-code-alt skills__icon' aria-hidden="true"></i> Languages & Scripting</h4>
+                            <div class="skills__tags" role="list" aria-labelledby="skills-cat-langs"> <!-- expose the styled pills as a list so screen readers announce them as grouped, countable items (WCAG 1.3.1) rather than run-together text; role has no visual effect -->
+                                <span class="skills__tag" role="listitem">Python</span>
+                                <span class="skills__tag" role="listitem">SQL</span>
+                                <span class="skills__tag" role="listitem">Google Apps Script</span>
+                                <span class="skills__tag" role="listitem">HTML / CSS</span>
                             </div>
                         </div>
 
@@ -867,48 +867,48 @@
                         -->
 
                         <div class="skills__category">
-                            <h4 class="skills__category-title"><i class='bx bx-bar-chart-alt-2 skills__icon' aria-hidden="true"></i> Data & Visualization</h4>
-                            <div class="skills__tags">
-                                <span class="skills__tag">Tableau</span>
-                                <span class="skills__tag">Looker</span>
-                                <span class="skills__tag">Qlik</span>
-                                <span class="skills__tag">Datorama</span>
-                                <span class="skills__tag">Mode Analytics</span>
-                                <span class="skills__tag">Excel</span>
-                                <span class="skills__tag">Google Sheets</span>
+                            <h4 class="skills__category-title" id="skills-cat-dataviz"><i class='bx bx-bar-chart-alt-2 skills__icon' aria-hidden="true"></i> Data & Visualization</h4>
+                            <div class="skills__tags" role="list" aria-labelledby="skills-cat-dataviz">
+                                <span class="skills__tag" role="listitem">Tableau</span>
+                                <span class="skills__tag" role="listitem">Looker</span>
+                                <span class="skills__tag" role="listitem">Qlik</span>
+                                <span class="skills__tag" role="listitem">Datorama</span>
+                                <span class="skills__tag" role="listitem">Mode Analytics</span>
+                                <span class="skills__tag" role="listitem">Excel</span>
+                                <span class="skills__tag" role="listitem">Google Sheets</span>
                             </div>
                         </div>
 
                         <div class="skills__category">
-                            <h4 class="skills__category-title"><i class='bx bx-data skills__icon' aria-hidden="true"></i> Analytics Platforms</h4>
-                            <div class="skills__tags">
-                                <span class="skills__tag">BigQuery</span>
-                                <span class="skills__tag">GA4</span>
-                                <span class="skills__tag">Adobe Analytics</span>
-                                <span class="skills__tag">Google Data Studio</span>
+                            <h4 class="skills__category-title" id="skills-cat-platforms"><i class='bx bx-data skills__icon' aria-hidden="true"></i> Analytics Platforms</h4>
+                            <div class="skills__tags" role="list" aria-labelledby="skills-cat-platforms">
+                                <span class="skills__tag" role="listitem">BigQuery</span>
+                                <span class="skills__tag" role="listitem">GA4</span>
+                                <span class="skills__tag" role="listitem">Adobe Analytics</span>
+                                <span class="skills__tag" role="listitem">Google Data Studio</span>
                             </div>
                         </div>
 
                         <div class="skills__category">
-                            <h4 class="skills__category-title"><i class='bx bx-cog skills__icon' aria-hidden="true"></i> Automation & Infrastructure</h4>
-                            <div class="skills__tags">
-                                <span class="skills__tag">Process Automation</span>
-                                <span class="skills__tag">ETL Pipelines</span>
-                                <span class="skills__tag">APIs</span>
-                                <span class="skills__tag">Docker</span>
-                                <span class="skills__tag">Linux</span>
-                                <span class="skills__tag">Git</span>
+                            <h4 class="skills__category-title" id="skills-cat-automation"><i class='bx bx-cog skills__icon' aria-hidden="true"></i> Automation & Infrastructure</h4>
+                            <div class="skills__tags" role="list" aria-labelledby="skills-cat-automation">
+                                <span class="skills__tag" role="listitem">Process Automation</span>
+                                <span class="skills__tag" role="listitem">ETL Pipelines</span>
+                                <span class="skills__tag" role="listitem">APIs</span>
+                                <span class="skills__tag" role="listitem">Docker</span>
+                                <span class="skills__tag" role="listitem">Linux</span>
+                                <span class="skills__tag" role="listitem">Git</span>
                             </div>
                         </div>
 
                         <div class="skills__category">
-                            <h4 class="skills__category-title"><i class='bx bx-bulb skills__icon' aria-hidden="true"></i> Strategy & Leadership</h4>
-                            <div class="skills__tags">
-                                <span class="skills__tag">Analytics Strategy</span>
-                                <span class="skills__tag">Stakeholder Communication</span>
-                                <span class="skills__tag">Data Storytelling</span>
-                                <span class="skills__tag">Dashboard Design</span>
-                                <span class="skills__tag">Cross-functional Collaboration</span>
+                            <h4 class="skills__category-title" id="skills-cat-strategy"><i class='bx bx-bulb skills__icon' aria-hidden="true"></i> Strategy & Leadership</h4>
+                            <div class="skills__tags" role="list" aria-labelledby="skills-cat-strategy">
+                                <span class="skills__tag" role="listitem">Analytics Strategy</span>
+                                <span class="skills__tag" role="listitem">Stakeholder Communication</span>
+                                <span class="skills__tag" role="listitem">Data Storytelling</span>
+                                <span class="skills__tag" role="listitem">Dashboard Design</span>
+                                <span class="skills__tag" role="listitem">Cross-functional Collaboration</span>
                                 <!-- <span class="skills__tag">Media Strategy</span> -->
                                 <!-- <span class="skills__tag">Roadmap Planning</span> -->
                             </div>

--- a/index.html
+++ b/index.html
@@ -724,7 +724,7 @@
 
                 <div class="home__img">
                     <div class="home__circle clickable-img" id="home-photo">
-                        <img src="assets/img/header.png" alt="Jacob Heifetz-Licht" class="home__circle-img" width="705" height="800" loading="lazy" decoding="async">
+                        <img src="assets/img/header.png" alt="Jacob Heifetz-Licht" class="home__circle-img" width="705" height="800" fetchpriority="high" decoding="async"> <!-- Hero image: the home section is the first section and this is the largest above-the-fold element (on mobile the .home__img flex order:-1 even renders it first), so it's the page LCP. It was loading="lazy" — a known LCP anti-pattern that defers the fetch until layout, delaying paint. This <img> is static markup, so the preload scanner finds it during head parse; making it eager (default) + fetchpriority="high" pulls it forward, matching the project-card LCP pattern near </body>. No visual change. -->
                     </div>
                 </div>
             </section>

--- a/index.html
+++ b/index.html
@@ -620,7 +620,7 @@
                         <button type="button" class="view-pill__btn is-active" data-view="projects" aria-pressed="true">Projects</button>
                         <button type="button" class="view-pill__btn" data-view="full" aria-pressed="false">Full site</button>
                     </div>
-                    <button id="theme-toggle" class="theme-toggle" aria-label="Switch to light mode" style="position: relative; top: 0;">
+                    <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Switch to light mode" style="position: relative; top: 0;">
                         <i class='bx bx-sun' id="theme-icon" aria-hidden="true"></i>
                     </button>
                     <script>
@@ -808,7 +808,7 @@
                         </ul>
                     </noscript>
 
-                    <button class="more-toggle" id="moreToggle" aria-expanded="false" aria-controls="moreWrap">
+                    <button type="button" class="more-toggle" id="moreToggle" aria-expanded="false" aria-controls="moreWrap">
                         <span id="moreLabel">Private projects</span>
                         <i class='bx bx-chevron-down' aria-hidden="true"></i>
                     </button>
@@ -969,12 +969,12 @@
         </footer>
 
         <!-- Scroll down arrow -->
-        <button class="scroll-down-arrow" id="scrollDown" aria-label="Scroll down">
+        <button type="button" class="scroll-down-arrow" id="scrollDown" aria-label="Scroll down">
             <i class='bx bx-chevron-down' aria-hidden="true"></i>
         </button>
 
         <!-- Back to top button -->
-        <button class="back-to-top" id="backToTop" aria-label="Back to top">
+        <button type="button" class="back-to-top" id="backToTop" aria-label="Back to top">
             <i class='bx bx-chevron-up' aria-hidden="true"></i>
         </button>
 
@@ -1010,18 +1010,18 @@
   <div class="modal-card">
     <div class="modal-bar">
       <div class="dots">
-        <button class="dot red" id="dotClose" title="Close" aria-label="Close preview"><svg viewBox="0 0 12 12" aria-hidden="true"><path d="M3.8 3.8 L8.2 8.2 M8.2 3.8 L3.8 8.2"/></svg></button>
-        <button class="dot yellow" id="dotMin" title="Minimize" aria-label="Minimize preview"><svg viewBox="0 0 12 12" aria-hidden="true"><path d="M3.3 6 H8.7"/></svg></button>
-        <button class="dot green" id="dotExpand" title="Full screen" aria-label="Full screen preview"><svg viewBox="0 0 12 12" aria-hidden="true"><path class="fill" d="M3 3 L3 7 L7 3 Z"/><path class="fill" d="M9 9 L9 5 L5 9 Z"/></svg></button>
+        <button type="button" class="dot red" id="dotClose" title="Close" aria-label="Close preview"><svg viewBox="0 0 12 12" aria-hidden="true"><path d="M3.8 3.8 L8.2 8.2 M8.2 3.8 L3.8 8.2"/></svg></button>
+        <button type="button" class="dot yellow" id="dotMin" title="Minimize" aria-label="Minimize preview"><svg viewBox="0 0 12 12" aria-hidden="true"><path d="M3.3 6 H8.7"/></svg></button>
+        <button type="button" class="dot green" id="dotExpand" title="Full screen" aria-label="Full screen preview"><svg viewBox="0 0 12 12" aria-hidden="true"><path class="fill" d="M3 3 L3 7 L7 3 Z"/><path class="fill" d="M9 9 L9 5 L5 9 Z"/></svg></button>
       </div>
-      <button class="nav-btn" id="navBack" title="Back" aria-label="Back" style="display:none;"><i class='bx bx-chevron-left' aria-hidden="true"></i></button>
-      <button class="nav-btn" id="navReload" title="Reload" aria-label="Reload"><i class='bx bx-revision' aria-hidden="true"></i></button>
+      <button type="button" class="nav-btn" id="navBack" title="Back" aria-label="Back" style="display:none;"><i class='bx bx-chevron-left' aria-hidden="true"></i></button>
+      <button type="button" class="nav-btn" id="navReload" title="Reload" aria-label="Reload"><i class='bx bx-revision' aria-hidden="true"></i></button>
       <form class="url-form" id="urlForm"><input class="modal-url" id="modalUrl" type="text" spellcheck="false" autocomplete="off" aria-label="Preview address"></form>
       <a class="openext" id="modalOpen" target="_blank" rel="noopener" title="Open in new tab" aria-label="Open preview in new tab"><i class='bx bx-link-external' aria-hidden="true"></i></a>
-      <button class="mclose" id="modalClose" title="Close" aria-label="Close preview"><span aria-hidden="true">×</span></button>
+      <button type="button" class="mclose" id="modalClose" title="Close" aria-label="Close preview"><span aria-hidden="true">×</span></button>
     </div>
     <div class="modal-body">
-      <button class="fs-back" id="fsBack" title="Back to projects"><i class='bx bx-arrow-back' aria-hidden="true"></i> Back</button>
+      <button type="button" class="fs-back" id="fsBack" title="Back to projects"><i class='bx bx-arrow-back' aria-hidden="true"></i> Back</button>
       <div class="modal-load" id="modalLoad"><div class="spin"></div><span id="modalLoadTxt">Loading preview…</span></div>
       <iframe class="modal-frame" id="modalFrame" title="Live preview" referrerpolicy="no-referrer-when-downgrade"></iframe>
       <button class="esc-hint" id="escHint" type="button" title="Exit preview">Press <kbd>Esc</kbd> to exit</button>
@@ -1130,7 +1130,7 @@ function rowHTML(p, eager){
         <p class="proj-one">${p.one}</p>
         <div class="work__cta proj-actions">
           ${ctaHTML(p)}
-          <button class="proj-chev" aria-label="Show details" aria-expanded="false" aria-controls="${detailId}"><i class='bx bx-chevron-down' aria-hidden="true"></i></button>
+          <button type="button" class="proj-chev" aria-label="Show details" aria-expanded="false" aria-controls="${detailId}"><i class='bx bx-chevron-down' aria-hidden="true"></i></button>
         </div>
       </div>
     </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,12 +2,12 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
         <loc>https://jacobhl.com/</loc>
-        <lastmod>2026-07-01</lastmod>
+        <lastmod>2026-07-03</lastmod>
         <priority>1.0</priority>
     </url>
     <url>
         <loc>https://jacobhl.com/weather/</loc>
-        <lastmod>2026-07-01</lastmod>
+        <lastmod>2026-07-03</lastmod>
         <priority>0.6</priority>
     </url>
 </urlset>

--- a/weather/index.html
+++ b/weather/index.html
@@ -388,7 +388,12 @@ function render(w, aqi, geo) {
     else if (usAqi <= 100) { aqiInfo.text = 'Moderate'; aqiInfo.color = '#f59e0b'; aqiInfo.aqi = 2; }
     else if (usAqi <= 150) { aqiInfo.text = 'Unhealthy (Sensitive)'; aqiInfo.color = '#f97316'; aqiInfo.aqi = 3; }
     else if (usAqi <= 200) { aqiInfo.text = 'Unhealthy'; aqiInfo.color = '#ef4444'; aqiInfo.aqi = 4; }
-    else { aqiInfo.text = 'Very Unhealthy'; aqiInfo.color = '#7c3aed'; aqiInfo.aqi = 5; }
+    else if (usAqi <= 300) { aqiInfo.text = 'Very Unhealthy'; aqiInfo.color = '#7c3aed'; aqiInfo.aqi = 5; }
+    // US AQI tops out at a distinct "Hazardous" band (301+), reached during wildfire smoke or in
+    // heavily polluted cities. Without this the dashboard mislabeled such readings as "Very
+    // Unhealthy". Keep aqi:5 so the 5-segment bar stays fully filled (no layout change); use the
+    // official EPA maroon so the value/segment colour reflects the more severe category.
+    else { aqiInfo.text = 'Hazardous'; aqiInfo.color = '#7e0023'; aqiInfo.aqi = 5; }
   }
 
   const sunrise = w.daily.sunrise[0];

--- a/weather/index.html
+++ b/weather/index.html
@@ -335,7 +335,10 @@ async function fetchWeather() {
       `wind_speed_unit=mph`,
       `precipitation_unit=inch`,
       `timezone=${encodeURIComponent(geo.tz)}`,
-      `forecast_days=7`
+      // render() reads daily indices 0–5 only (index 0 for sun times/UV, 1–5 for the "5-Day
+      // Forecast"), and the hourly card shows just a 12h window — so the 7th forecast day was
+      // fetched (as a daily row AND ~24 extra hourly entries) but never used. Request 6.
+      `forecast_days=6`
     ].join('&');
 
     // Kick off both requests in parallel. Weather is required; air quality is optional and must

--- a/weather/index.html
+++ b/weather/index.html
@@ -235,6 +235,12 @@ body {
 
 <!-- Open-Meteo requires attribution: its weather/air-quality data is published under CC BY 4.0. -->
 <footer class="attribution">
+  <!-- This dashboard is reachable by direct URL / search (it's in the sitemap and canonical'd) but
+       isn't linked from the portfolio, so without this a JS-enabled visitor has no way back to the
+       main site — the /-link in the <noscript> block only shows when JavaScript is disabled. Uses
+       the existing .attribution link styling; the arrow is decorative, so it's aria-hidden (mirrors
+       the ↑/↓ sun-times markup). -->
+  <a href="/"><span aria-hidden="true">&larr;</span> Back to jacobhl.com</a><br>
   Weather &amp; air-quality data by <a href="https://open-meteo.com/" target="_blank" rel="noopener">Open-Meteo.com</a> (CC&nbsp;BY&nbsp;4.0)
 </footer>
 

--- a/weather/index.html
+++ b/weather/index.html
@@ -135,7 +135,9 @@ body {
   .hero-right { text-align:center; }
 }
 
-.stat-label { font-size:11px; text-transform:uppercase; letter-spacing:1px; color:var(--text-dim); margin-bottom:6px; }
+/* Also used on the <h2> stat-card labels (Humidity / Air Quality / Sunrise), so reset the
+   heading UA defaults (bold + top margin) to keep these rendering exactly as the old <div>s did. */
+.stat-label { font-size:11px; font-weight:400; text-transform:uppercase; letter-spacing:1px; color:var(--text-dim); margin:0 0 6px; }
 .stat-value { font-size:24px; font-weight:600; }
 .stat-sub { font-size:12px; color:var(--text-dim); margin-top:2px; }
 .stat-icon { font-size:20px; margin-bottom:8px; }
@@ -515,7 +517,7 @@ function render(w, aqi, geo) {
   // Humidity comfort
   html += `<div class="card">
     <div class="stat-icon" aria-hidden="true">💧</div>
-    <div class="stat-label">Humidity Comfort</div>
+    <h2 class="stat-label">Humidity Comfort</h2>
     <div class="stat-value">${humidity}%</div>
     <div class="stat-sub">${comfort.label}</div>
     <div class="comfort-meter">${[1,2,3,4].map(i => `<div class="comfort-seg ${i <= comfort.level ? comfort.cls : ''}"></div>`).join('')}</div>
@@ -524,7 +526,7 @@ function render(w, aqi, geo) {
   // AQI
   html += `<div class="card">
     <div class="stat-icon" aria-hidden="true">🌬️</div>
-    <div class="stat-label">Air Quality${usAqi != null ? ' (US AQI: '+usAqi+')' : ''}</div>
+    <h2 class="stat-label">Air Quality${usAqi != null ? ' (US AQI: '+usAqi+')' : ''}</h2>
     <div class="stat-value" style="color:${aqiInfo.color}">${aqiInfo.text}</div>
     <div class="stat-sub">${pm25 != null ? 'PM2.5: ' + pm25.toFixed(1) + ' µg/m³' : ''}</div>
     <div class="aqi-bar">${[1,2,3,4,5].map(i => `<div class="aqi-seg" style="background:${i <= aqiInfo.aqi ? aqiInfo.color : 'rgba(255,255,255,.08)'}"></div>`).join('')}</div>
@@ -533,7 +535,7 @@ function render(w, aqi, geo) {
   // Sunrise/Sunset
   html += `<div class="card">
     <div class="stat-icon" aria-hidden="true">🌅</div>
-    <div class="stat-label">Sunrise / Sunset</div>
+    <h2 class="stat-label">Sunrise / Sunset</h2>
     <div class="sun-bar"><div class="sun-dot" style="left:calc(${sunProg}% - 7px)"></div></div>
     <div class="sun-times">
       <span><span aria-hidden="true">↑</span><span class="visually-hidden">Sunrise: </span> ${fmtTime(sunrise)}</span>

--- a/weather/index.html
+++ b/weather/index.html
@@ -401,9 +401,15 @@ function render(w, aqi, geo) {
 
   const uvMax = w.daily.uv_index_max[0];
 
-  // Next 24 hours of hourly data
-  const nowHour = new Date().getHours();
-  const hourlyStart = w.hourly.time.findIndex(t => new Date(t).getHours() >= nowHour && new Date(t) >= new Date(new Date().toDateString()));
+  // Next 12 hours of hourly data. The API returns hourly times in the SEARCHED CITY's timezone
+  // (we pass timezone=geo.tz), so anchor "now" to the city's own clock via w.current.time rather
+  // than the browser's — otherwise the window started at the viewer's local hour and was shifted
+  // for any city in a different timezone (e.g. searching Tokyo from New York). Compare the ISO
+  // "YYYY-MM-DDTHH" hour prefixes so it's a pure string match, immune to how new Date() localizes
+  // these offset-less stamps. (|| '') falls back to the first slot if current.time is ever absent.
+  const cityNowHour = (c.time || '').slice(0, 13);
+  let hourlyStart = w.hourly.time.findIndex(t => t.slice(0, 13) >= cityNowHour);
+  if (hourlyStart === -1) hourlyStart = 0; // defensive: never let the loop start at index -1
   const hourly = [];
   for (let i = hourlyStart; i < Math.min(hourlyStart + 12, w.hourly.time.length); i++) {
     hourly.push({

--- a/weather/index.html
+++ b/weather/index.html
@@ -487,7 +487,10 @@ function render(w, aqi, geo) {
         Humidity: ${humidity}%<br>
         Wind: ${windSpeed} mph ${windD}${gusts ? '<br>Gusts: ' + gusts + ' mph' : ''}<br>
         Pressure: ${pressure} inHg<br>
-        UV Index: ${uvMax} ${uvMax <= 2 ? '(Low)' : uvMax <= 5 ? '(Moderate)' : uvMax <= 7 ? '(High)' : '(Very High)'}
+        <!-- EPA UV Index scale tops out at a distinct "Extreme" band (11+), reached at high
+             altitude/near the equator or under ozone-thinned skies. Without this, such readings
+             were mislabeled "Very High". Mirrors the AQI "Hazardous" band fix. -->
+        UV Index: ${uvMax} ${uvMax <= 2 ? '(Low)' : uvMax <= 5 ? '(Moderate)' : uvMax <= 7 ? '(High)' : uvMax <= 10 ? '(Very High)' : '(Extreme)'}
       </div>
     </div>
   </div>`;

--- a/weather/index.html
+++ b/weather/index.html
@@ -469,11 +469,15 @@ function render(w, aqi, geo) {
 
   // Daily forecast
   const days = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+  // Full weekday names for screen readers — the visible column shows the 3-letter abbreviation,
+  // but "Mon"/"Tue" are announced ambiguously by assistive tech, so expose the full name too.
+  const daysFull = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
   const dailyRows = [];
   for (let i = 1; i < Math.min(6, w.daily.time.length); i++) {
     const d = new Date(w.daily.time[i] + 'T12:00:00');
     dailyRows.push({
       day: days[d.getDay()],
+      dayFull: daysFull[d.getDay()],
       code: w.daily.weather_code[i],
       hi: Math.round(w.daily.temperature_2m_max[i]),
       lo: Math.round(w.daily.temperature_2m_min[i]),
@@ -565,14 +569,16 @@ function render(w, aqi, geo) {
   // 5-day forecast
   html += `<div class="card">
     <h2 class="section-title"><span aria-hidden="true">📅</span> 5-Day Forecast</h2>
+    <div class="forecast-list" role="list" aria-label="5-day forecast">
     ${dailyRows.map(d => {
-      return `<div class="forecast-row">
-        <div class="forecast-day">${d.day}</div>
+      return `<div class="forecast-row" role="listitem">
+        <div class="forecast-day"><span class="visually-hidden">${d.dayFull}</span><span aria-hidden="true">${d.day}</span></div>
         <div class="forecast-icon" aria-hidden="true">${getIcon(d.code, true)}</div>
         <div class="forecast-desc">${getDesc(d.code)}${d.pop > 20 ? ' · ' + d.pop + '% rain' : ''}</div>
         <div class="forecast-temps"><span class="hi"><span class="visually-hidden">High: </span>${d.hi}°</span> <span aria-hidden="true">/</span> <span class="lo"><span class="visually-hidden">Low: </span>${d.lo}°</span></div>
       </div>`;
     }).join('')}
+    </div>
   </div>`;
 
   // NYC tip — the dashboard is NYC-themed (defaults to New York), and the advice below is

--- a/weather/index.html
+++ b/weather/index.html
@@ -393,7 +393,15 @@ function render(w, aqi, geo) {
 
   const sunrise = w.daily.sunrise[0];
   const sunset = w.daily.sunset[0];
-  const now = new Date();
+  // Anchor "now" to the SEARCHED CITY's clock, not the viewer's. sunrise/sunset are offset-less
+  // ISO stamps in the city's timezone (we pass timezone=geo.tz), and sunProgress parses them via
+  // new Date() — i.e. as browser-local wall-clock. So compare them against the city's current
+  // local time (w.current.time, parsed the same offset-less way), not the browser's real instant.
+  // With new Date() the sun-arc dot was placed by the viewer's clock, so it sat at the wrong spot
+  // for any city in a different timezone (e.g. Tokyo viewed from New York). Mirrors the hourly-
+  // window fix. Falls back to the browser clock if current.time is ever absent. No visual change
+  // for same-timezone use.
+  const now = c.time ? new Date(c.time) : new Date();
   const sunProg = sunProgress(sunrise, sunset, now);
   const daylightSec = (new Date(sunset) - new Date(sunrise)) / 1000;
   const dlH = Math.floor(daylightSec/3600);

--- a/weather/index.html
+++ b/weather/index.html
@@ -327,7 +327,9 @@ async function fetchWeather() {
     const params = [
       `latitude=${geo.lat}`, `longitude=${geo.lon}`,
       `current=temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m,wind_gusts_10m,surface_pressure,is_day`,
-      `hourly=temperature_2m,precipitation_probability,weather_code,is_day`,
+      // Hourly card renders only rain chance + an icon (see render()), so request just those
+      // fields — hourly temperature_2m was fetched for all 168 forecast hours but never used.
+      `hourly=precipitation_probability,weather_code,is_day`,
       `daily=weather_code,temperature_2m_max,temperature_2m_min,sunrise,sunset,uv_index_max,precipitation_probability_max`,
       `temperature_unit=fahrenheit`,
       `wind_speed_unit=mph`,

--- a/weather/index.html
+++ b/weather/index.html
@@ -500,8 +500,11 @@ function render(w, aqi, geo) {
         Pressure: ${pressure} inHg<br>
         <!-- EPA UV Index scale tops out at a distinct "Extreme" band (11+), reached at high
              altitude/near the equator or under ozone-thinned skies. Without this, such readings
-             were mislabeled "Very High". Mirrors the AQI "Hazardous" band fix. -->
-        UV Index: ${uvMax} ${uvMax <= 2 ? '(Low)' : uvMax <= 5 ? '(Moderate)' : uvMax <= 7 ? '(High)' : uvMax <= 10 ? '(Very High)' : '(Extreme)'}
+             were mislabeled "Very High". Mirrors the AQI "Hazardous" band fix.
+             Open-Meteo can return null for uv_index_max (e.g. polar-night days with no UV model
+             value); guard it so the hero shows "N/A" instead of the literal "null (Low)", mirroring
+             the AQI null → "N/A" handling above. -->
+        UV Index: ${uvMax != null ? `${uvMax} ${uvMax <= 2 ? '(Low)' : uvMax <= 5 ? '(Moderate)' : uvMax <= 7 ? '(High)' : uvMax <= 10 ? '(Very High)' : '(Extreme)'}` : 'N/A'}
       </div>
     </div>
   </div>`;


### PR DESCRIPTION
Automated, low-risk improvements to jacobhl.com. Each run adds one small, safe, text-only change on the `auto/staging` branch for review. Design/aesthetics are preserved; media assets are never touched. Preview via the diff below or by running locally (GitHub Pages does not build branch previews).

### Checklist
- [x] **weather/index.html** — Fix a timezone bug in the hourly forecast: the 12-hour window was anchored to the browser's current hour (`new Date()`), but the API returns hourly times in the searched city's timezone. Now anchored to `w.current.time` (the city's own clock). No visual change for same-timezone use.
- [x] **weather/index.html** — Fix the same class of timezone bug in the sun-arc/daylight card: `sunProgress()` compared offset-less sunrise/sunset stamps against the browser's real instant. Now anchors `now` to the city's clock (`w.current.time`), falling back to the browser clock if absent.
- [x] **index.html** — Add a baseline `aria-current="page"` to the active Home nav link, matching the `active-link` + `aria-current` pairing `main.js` sets everywhere else. No visual change.
- [x] **weather/index.html** — Add the missing top **"Hazardous"** US AQI category: readings above 300 were mislabeled "Very Unhealthy". `> 300` is now "Hazardous" (EPA maroon), keeping `aqi:5` so the bar renders identically.
- [x] **index.html** — Fix the theme-toggle's baseline icon/`aria-label` for returning light-mode users (button was hardcoded in its dark state, corrected only later by `main.js`). Added a guarded inline script after the button. No visual change for dark-mode users.
- [x] **404.html** — Apply the same theme-toggle baseline fix to the 404 page for consistency. Identical guarded inline script. No visual change for dark-mode users.
- [x] **weather/index.html** — Add the missing top **"Extreme"** UV Index band (11+): readings above 10 were swept into "Very High". `> 10` is now "Extreme". One-line text change, no layout impact.
- [x] **weather/index.html** — Drop the unused `temperature_2m` field from the hourly API request (the hourly card renders only rain chance + an icon). No behavioral or visual change.
- [x] **weather/index.html** — Trim the unused 7th forecast day from the Open-Meteo request (`forecast_days=7` → `6`). `render()` reads only daily indices 0–5. No behavioral or visual change.
- [x] **weather/index.html** — Add a "Back to jacobhl.com" footer link so the standalone, indexed dashboard isn't a dead end for JS-enabled visitors.
- [x] **styles.css** — Add a branded `:focus-visible` ring to the hero/footer social icon links and the nav toggle so keyboard focus is visible. No change for mouse users.
- [x] **weather/index.html** — Show "N/A" for a null UV index instead of the literal "null (Low)".
- [x] **index.html** — Add a branded `:focus-visible` ring to the live-preview modal toolbar controls.
- [x] **sitemap.xml** — Refresh stale `lastmod` dates to 2026-07-03.
- [x] **index.html** — Add a branded `:focus-visible` ring to the Projects LinkedIn icon link and the "Private projects" toggle.
- [x] **weather/index.html** — Promote the three stat-card labels (Humidity Comfort, Air Quality, Sunrise/Sunset) to `<h2>` so screen-reader heading navigation reaches them, like every other card block. Reset the heading UA defaults on `.stat-label` (font-weight:400, no top margin) so rendering is byte-for-byte identical.
- [x] **index.html** — Give the skill-tag pill groups ARIA list semantics: `role="list"` on each of the 5 visible category containers (labelled by their `<h4>` via `aria-labelledby`) and `role="listitem"` on the 26 pills, so screen readers announce them as grouped, countable items (WCAG 1.3.1). ARIA roles have no visual effect.
- [x] **index.html** — Remove a duplicate `[data-theme="dark"] .proj-chev{color:#e0e0e0}` rule pasted *after* `.proj-chev:hover`; with equal specificity it won the cascade, so in dark mode a hovered project chevron kept its grey icon instead of the intended accent colour. Removing it restores consistent hover across both themes.
- [x] **index.html** — Eager-load the hero image (`header.png`). It was `loading="lazy"`, but the home section is first and this is the largest above-the-fold element (on mobile `.home__img order:-1` renders it first), making it the page LCP — lazy-loading an LCP image is a known anti-pattern. Removed `loading="lazy"` and added `fetchpriority="high"`. No visual change.
- [x] **weather/index.html** — Give the 5-Day Forecast ARIA list semantics (`role="list"` wrapper + `role="listitem"` on each day row) and expose the full weekday name (`Monday` …) via a `.visually-hidden` span while the visible column keeps its 3-letter abbreviation. No visual change.
- [x] **index.html** — Add an explicit `type="button"` to the 12 non-submit `<button>` controls (theme toggle, "Private projects" toggle, scroll-down/back-to-top arrows, live-preview modal controls, project chevron) so they can't accidentally act as `type="submit"` if the markup is ever restructured — matching the convention the newer buttons (view-pill, weather Search, Esc-hint) already follow. Text-only; no visual or behavioral change.