### PR TITLE
Auto-improvements (staging)

### DIFF
--- a/404.html
+++ b/404.html
@@ -104,7 +104,7 @@
                     </ul>
                 </div>
                 <div style="display: flex; align-items: center;">
-                    <button id="theme-toggle" class="theme-toggle" aria-label="Switch to light mode" style="position: relative; top: -2px;">
+                    <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Switch to light mode" style="position: relative; top: -2px;">
                         <i class='bx bx-sun' id="theme-icon" aria-hidden="true"></i>
                     </button>
                     <script>

--- a/404.html
+++ b/404.html
@@ -4,6 +4,8 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="theme-color" content="#090f20">
+        <!-- Declare supported colour schemes to the UA up front. color-scheme is otherwise only set inside the render-blocking styles.css (:root=light, [data-theme="dark"]=dark), so before that CSS loads the browser doesn't know this is a dark-default page and paints the root canvas/scrollbars with the OS default (a brief light flash for the majority dark view). "dark light" matches the document's literal default (<html data-theme="dark">) while still advertising light-mode support (the inline script above can switch to light); the CSS color-scheme rules take over once loaded. Mirrors index.html. No visual change to the settled page. -->
+        <meta name="color-scheme" content="dark light">
         <meta name="robots" content="noindex, follow">
         <link rel="stylesheet" href="/assets/css/styles.css">
         <link rel="icon" type="image/x-icon" href="/assets/img/favicon.ico">

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -757,12 +757,24 @@ function requestResume() {
 /*===== CONTACT FORM SUBMIT =====*/
 const contactForm = document.querySelector('.contact__form');
 if (contactForm) {
+    // Screen-reader status region: on submit the button is set disabled (which drops it
+    // from the accessibility tree), so its visible "Sending…/Sent!/Error" text change is
+    // never announced — screen-reader users get no feedback that the message went through.
+    // Mirror the button's state into a polite live region, created once up front so AT
+    // registers it before the first update. Mirrors the weather dashboard's #srStatus.
+    const srStatus = document.createElement('div');
+    srStatus.setAttribute('role', 'status');
+    srStatus.setAttribute('aria-live', 'polite');
+    srStatus.style.cssText = 'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;';
+    contactForm.appendChild(srStatus);
+
     contactForm.addEventListener('submit', function(e) {
         e.preventDefault();
         const btn = contactForm.querySelector('.contact__button');
         const origText = btn.textContent;
         btn.textContent = 'Sending...';
         btn.disabled = true;
+        srStatus.textContent = 'Sending your message…';
 
         fetch(contactForm.action, {
             method: 'POST',
@@ -774,15 +786,18 @@ if (contactForm) {
                 btn.textContent = 'Sent!';
                 btn.style.transition = 'none';
                 btn.style.background = '#28a745';
+                srStatus.textContent = 'Message sent — thanks! I\'ll get back to you soon.';
                 setTimeout(() => { btn.textContent = origText; btn.disabled = false; btn.style.background = ''; btn.style.transition = ''; }, 4000);
             } else {
                 btn.textContent = 'Error — try again';
                 btn.style.background = '#dc3545';
+                srStatus.textContent = 'Something went wrong sending your message. Please try again.';
                 setTimeout(() => { btn.textContent = origText; btn.disabled = false; btn.style.background = ''; }, 3000);
             }
         }).catch(() => {
             btn.textContent = 'Error — try again';
             btn.style.background = '#dc3545';
+            srStatus.textContent = 'Something went wrong sending your message. Please try again.';
             setTimeout(() => { btn.textContent = origText; btn.disabled = false; btn.style.background = ''; }, 3000);
         });
     });

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -239,29 +239,39 @@ const revealElements = document.querySelectorAll(
   '.contact__input, .contact__button'
 );
 
-revealElements.forEach(el => el.classList.add('reveal'));
+// Only run the hide-then-reveal enhancement when IntersectionObserver is available. Adding the
+// .reveal class sets opacity:0, and the observer is what adds .visible to fade each element in —
+// so if the observer is missing (unsupported browsers) or its construction throws, that .visible
+// is never applied and the reveal content (section titles, about/skills text, contact form) would
+// stay permanently invisible. Worse, an uncaught throw here at top level would halt the rest of
+// main.js below (contact-form submit, scroll arrows, live-dot observer). Guard the whole block so
+// unsupported browsers simply keep the default visible layout. Mirrors the live-dot observer's
+// feature guard further down; no change in modern browsers.
+if ('IntersectionObserver' in window) {
+  revealElements.forEach(el => el.classList.add('reveal'));
 
-const revealObserver = new IntersectionObserver((entries) => {
-  entries.forEach(entry => {
-    if (entry.isIntersecting) {
-      entry.target.classList.add('visible');
-      revealObserver.unobserve(entry.target);
+  const revealObserver = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        revealObserver.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.15 });
+
+  // Stagger siblings so they cascade
+  let lastParent = null;
+  let staggerIndex = 0;
+  revealElements.forEach(el => {
+    if (el.parentElement !== lastParent) {
+      lastParent = el.parentElement;
+      staggerIndex = 0;
     }
+    el.style.transitionDelay = (staggerIndex * 0.1) + 's';
+    staggerIndex++;
+    revealObserver.observe(el);
   });
-}, { threshold: 0.15 });
-
-// Stagger siblings so they cascade
-let lastParent = null;
-let staggerIndex = 0;
-revealElements.forEach(el => {
-  if (el.parentElement !== lastParent) {
-    lastParent = el.parentElement;
-    staggerIndex = 0;
-  }
-  el.style.transitionDelay = (staggerIndex * 0.1) + 's';
-  staggerIndex++;
-  revealObserver.observe(el);
-});
+}
 
 /*===== IMAGE CLICK EFFECTS (confetti, bursts, mega-explosion) =====*/
 function spawnConfetti(x, y, count) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -140,21 +140,26 @@ function setThemeColor(theme) {
 // HTML defaults to data-theme="dark" and sun icon; only switch to light if user previously chose light
 if (currentTheme === 'light') {
     document.documentElement.removeAttribute('data-theme');
-    themeIcon.classList.replace('bx-sun', 'bx-moon');
-    themeToggle.setAttribute('aria-label', 'Switch to dark mode');
+    if (themeIcon) themeIcon.classList.replace('bx-sun', 'bx-moon');
+    if (themeToggle) themeToggle.setAttribute('aria-label', 'Switch to dark mode');
     setThemeImages('light');
     setThemeColor('light');
 } else {
     document.documentElement.setAttribute('data-theme', 'dark');
-    themeIcon.classList.replace('bx-moon', 'bx-sun');
-    themeToggle.setAttribute('aria-label', 'Switch to light mode');
+    if (themeIcon) themeIcon.classList.replace('bx-moon', 'bx-sun');
+    if (themeToggle) themeToggle.setAttribute('aria-label', 'Switch to light mode');
     setThemeColor('dark');
     if (currentTheme !== 'dark') {
         safeSetItem('theme', 'dark');
     }
 }
 
-themeToggle.addEventListener('click', () => {
+// Guard the toggle wiring: this block runs first in main.js, so an uncaught throw here
+// (were the toggle markup ever renamed/removed) would halt the rest of the file — nav,
+// scroll reveal, contact-form submit, scroll arrows. Every other DOM dependency below is
+// already guarded this way; the toggle exists on every page that loads main.js today, so
+// this is purely defensive with no behavior change.
+if (themeToggle) themeToggle.addEventListener('click', () => {
     const root = document.documentElement;
     root.classList.add('theme-switching'); // make the swap instant (no color-transition lag)
     const currentTheme = root.getAttribute('data-theme');

--- a/index.html
+++ b/index.html
@@ -89,9 +89,8 @@
             .clickable-img.bg-removed {
                 mix-blend-mode: screen;
             }
-            [data-theme="dark"] .clickable-img.bg-removed {
-                mix-blend-mode: screen;
-            }
+            /* Light mode only: the base rule above already gives dark mode its "screen"
+               blend, so only the light theme needs to override it to "multiply". */
             html:not([data-theme="dark"]) .clickable-img.bg-removed {
                 mix-blend-mode: multiply;
             }

--- a/index.html
+++ b/index.html
@@ -937,7 +937,8 @@
                         <input type="text" name="name" placeholder="Your Name" class="contact__input" aria-label="Your name" autocomplete="name" required>
                         <input type="email" name="email" placeholder="your@email.com" class="contact__input" aria-label="Your email address" autocomplete="email" required>
                         <textarea name="message" placeholder="Your Message" class="contact__input" aria-label="Your message" rows="10" required></textarea>
-                        <button type="submit" class="contact__button button" aria-live="polite">Send</button>
+                        <!-- No aria-live here: the button is set disabled on submit (dropping it from the a11y tree), and main.js mirrors the "Sending…/Sent!/Error" status into a dedicated visually-hidden #srStatus live region. Keeping aria-live on the button too caused a redundant/inconsistent double announcement. -->
+                        <button type="submit" class="contact__button button">Send</button>
                     </form>
                 </div>
             </section>

--- a/index.html
+++ b/index.html
@@ -1088,7 +1088,7 @@ function ctaHTML(p){
   let h='';
   if(p.site){ const _d=(()=>{try{return new URL(p.site).hostname.replace(/^www\./,'')}catch(e){return ''}})();
     const _fav = USE_FAVICONS && FAVICONS[_d];
-    const _inner = _fav ? `<img class="favicon" src="${_fav}" alt="" loading="lazy">` : `<i class='bx bx-globe' aria-hidden="true"></i>`;
+    const _inner = _fav ? `<img class="favicon" src="${_fav}" alt="" width="20" height="20" loading="lazy" decoding="async">` : `<i class='bx bx-globe' aria-hidden="true"></i>`;
     h+=`<a href="${p.site}" target="_blank" rel="noopener" class="site-link" title="Visit website" aria-label="Visit the ${p.title} website">${_inner}</a>`; }
   if(p.appstore) h+=`<a href="${p.appstore}" target="_blank" rel="noopener" class="app-store-badge-link" aria-label="Download ${p.title} on the App Store"><img src="assets/img/app-store-badge.svg" alt="" class="app-store-badge" width="120" height="40" decoding="async"></a>`;
   if(p.download) h+=`<a href="${p.download}" class="mac-badge" title="Download TidyTab for macOS (.dmg, notarized)"><i class='bx bxl-apple' aria-hidden="true"></i><span class="mb-txt"><span class="mb-top">Download for</span><span class="mb-big">Mac</span></span></a>`;

--- a/index.html
+++ b/index.html
@@ -1178,7 +1178,16 @@ function navigate(url, push){
   let _host=url; try{ _host=new URL(url).hostname.replace(/^www\./,''); }catch(e){}
   frame.src=url; frame.title='Live preview of '+_host; mUrl.value=url; mOpen.href=url;
   clearTimeout(loadTimer);
-  loadTimer=setTimeout(()=>{ mLoadTxt.innerHTML=`Taking a while — <a href="${url}" target="_blank" rel="noopener">open ${url} ↗</a>`; }, 6000);
+  // Build the fallback link via DOM APIs rather than innerHTML: `url` can come from the user-typed
+  // preview address bar (navigate(u,true) below), so interpolating it into an HTML string is a
+  // self-XSS vector — the .href setter and textContent treat it as inert data instead. Same
+  // concern the weather dashboard guards against when rendering user input. Renders identically.
+  loadTimer=setTimeout(()=>{
+    mLoadTxt.textContent='Taking a while — ';
+    const _a=document.createElement('a');
+    _a.href=url; _a.target='_blank'; _a.rel='noopener'; _a.textContent='open '+url+' ↗';
+    mLoadTxt.appendChild(_a);
+  }, 6000);
 }
 // WAI-ARIA modal-dialog pattern: while the preview is open, hide the rest of the page from
 // assistive tech and keyboard/pointer input, complementing the Tab focus-trap below. The Tab

--- a/index.html
+++ b/index.html
@@ -1181,6 +1181,13 @@ function navigate(url, push){
   // so screen-reader users entering the frame hear which site this preview is showing.
   let _host=url; try{ _host=new URL(url).hostname.replace(/^www\./,''); }catch(e){}
   frame.src=url; frame.title='Live preview of '+_host; mUrl.value=url; mOpen.href=url;
+  // Match the dialog's accessible name to the site being previewed. The container's static
+  // aria-label is the generic "Live site preview", so a screen-reader user opening the preview
+  // (focus lands on the close button) hears "Live site preview dialog" without learning which
+  // project it is. Name it per-host — mirroring the iframe title set just above — so the dialog
+  // announces the actual site. Set here (openModal calls navigate on open) so it's fresh at open
+  // time and stays correct as the user navigates within the preview.
+  modal.setAttribute('aria-label', 'Live preview of '+_host);
   clearTimeout(loadTimer);
   // Build the fallback link via DOM APIs rather than innerHTML: `url` can come from the user-typed
   // preview address bar (navigate(u,true) below), so interpolating it into an HTML string is a

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="theme-color" content="#090f20">
+        <!-- Declare supported colour schemes to the UA up front. color-scheme is otherwise only set inside the render-blocking styles.css (:root=light, [data-theme="dark"]=dark), so before that CSS loads the browser doesn't know this is a dark-default page and paints the root canvas/scrollbars with the OS default (a brief light flash for the majority dark view). "dark light" matches the document's literal default (<html data-theme="dark">) while still advertising light-mode support; the CSS color-scheme rules take over once loaded. No visual change to the settled page. -->
+        <meta name="color-scheme" content="dark light">
         <link rel="stylesheet" href="assets/css/styles.css">
         <link rel="icon" type="image/x-icon" href="assets/img/favicon.ico">
         <link rel="preconnect" href="https://cdn.jsdelivr.net"> <!-- early-connect for the render-blocking boxicons CSS fetch (non-CORS, so it can't reuse the crossorigin socket below) -->

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
         <link rel="preload" as="image" href="assets/img/hidescore-app.png" media="(max-width:767.98px)" fetchpriority="high"> <!-- LCP preload (mobile <768px): same as above for the default <picture> source. The two media queries are mutually exclusive, so only the one image the browser will actually render is ever preloaded (no wasted bytes). -->
         <link rel="dns-prefetch" href="//gc.zgo.at"> <!-- resolve the GoatCounter analytics host ahead of the async count.js fetch at end of body -->
         <link rel="dns-prefetch" href="//stats.hidescore.com"> <!-- resolve the self-hosted Umami analytics host ahead of its deferred script.js fetch at end of body -->
+        <link rel="dns-prefetch" href="//formspree.io"> <!-- resolve the Formspree host ahead of the contact form's on-submit POST (assets/js/main.js) so the DNS lookup isn't on the send path -->
         <link href='https://cdn.jsdelivr.net/npm/boxicons@2.0.5/css/boxicons.min.css' rel='stylesheet'> <!-- icons -->
         <script>
             // Default view = projects-only (set before paint to avoid flash); honor saved preference.

--- a/index.html
+++ b/index.html
@@ -793,14 +793,16 @@
                     <div id="main-rows"></div>
                     <noscript>
                         <!-- The project cards above are built by JavaScript, so with scripting disabled
-                             (or for crawlers that don't run JS) #main-rows is empty. List the live
-                             projects as plain links so the core content and its SEO value aren't lost. -->
+                             (or for crawlers that don't run JS) #main-rows is empty. List the projects
+                             as plain links so the core content and its SEO value aren't lost. Mirrors the
+                             MAIN[] array; TidyTab has no website, so it links to its browsable GitHub repo. -->
                         <ul style="list-style:none;margin:0;padding:0;line-height:1.6;color:var(--text-color,#8b94a0);">
                             <li><a href="https://hidescore.com" target="_blank" rel="noopener noreferrer">HideScore</a> — Watch sports highlights without seeing the score.</li>
                             <li><a href="https://tonightnyc.com" target="_blank" rel="noopener noreferrer">Tonight NYC</a> — Every NYC comedy show, filtered to your favorite comedians.</li>
                             <li><a href="https://subwaytimes.com" target="_blank" rel="noopener noreferrer">Subway Times</a> — Real-time NYC subway arrivals, faster than Maps.</li>
                             <li><a href="https://davidlicht.com" target="_blank" rel="noopener noreferrer">David Licht</a> — A showcase site for my dad — five decades of drumming.</li>
                             <li><a href="https://theisland.nyc" target="_blank" rel="noopener noreferrer">The Island</a> — Everything happening on NYC's Roosevelt Island, in one place.</li>
+                            <li><a href="https://github.com/jacobhl3ca/safari-pinned-tab-automation" target="_blank" rel="noopener noreferrer">TidyTab</a> — Bulk unpin or close Safari pinned tabs, a macOS menu-bar app.</li>
                         </ul>
                     </noscript>
 

--- a/index.html
+++ b/index.html
@@ -1115,7 +1115,7 @@ function rowHTML(p, eager){
   return `
   <div class="proj-row">
     <div class="proj-head">
-      <div class="proj-thumb ${thumbCls}" ${p.live?`data-url="${p.url}" role="button" tabindex="0" aria-label="Open live preview of ${p.title}"`:''}>
+      <div class="proj-thumb ${thumbCls}" ${p.live?`data-url="${p.url}" role="button" tabindex="0" aria-haspopup="dialog" aria-label="Open live preview of ${p.title}"`:''}>
         ${p.imgWide
           ? `<picture><source media="(min-width:768px)" srcset="${p.imgWide}"><img src="${p.img}" alt="${p.live ? '' : p.title + ' screenshot'}" ${imgLoad} decoding="async"></picture>`
           : `<img src="${p.img}" alt="${p.live ? '' : p.title + ' screenshot'}" ${imgLoad} decoding="async">`}

--- a/index.html
+++ b/index.html
@@ -131,12 +131,6 @@
                 box-shadow: 0 4px 16px rgba(0,0,0,0.3);
                 animation: code-float 1.8s ease-out forwards;
             }
-            html:not([data-theme="dark"]) .code-popup {
-                background: rgba(30, 30, 60, 0.92);
-                color: #43e97b;
-                border-color: rgba(67, 233, 123, 0.4);
-                box-shadow: 0 4px 16px rgba(0,0,0,0.3);
-            }
             @keyframes code-float {
                 0% { opacity: 0; transform: translateY(0) scale(0.7); }
                 15% { opacity: 1; transform: translateY(-10px) scale(1); }

--- a/light/index.html
+++ b/light/index.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Declare the colour scheme to the UA up front. This entry page forces light mode (it sets theme=light below, then redirects), so "light" is correct — it stops OS-dark browsers painting the root canvas/scrollbars dark for the brief redirect paint. Mirrors the color-scheme declarations on index.html, 404.html, and weather/index.html; completes the site-wide pattern. No visual change. -->
+    <meta name="color-scheme" content="light">
     <!-- No-JS fallback: redirect to the main site even when scripting is disabled (the script below handles the JS path) -->
     <meta http-equiv="refresh" content="0; url=/">
     <title>Jacob Heifetz-Licht</title>

--- a/weather/index.html
+++ b/weather/index.html
@@ -17,6 +17,7 @@
     "@type": "WebApplication",
     "name": "Weather Dashboard",
     "url": "https://jacobhl.com/weather/",
+    "image": "https://jacobhl.com/assets/img/og_image.png",
     "description": "A live weather dashboard with current conditions, hourly rain chance, a 5-day forecast, air quality, and sun times. Search any city — defaults to New York, NY.",
     "applicationCategory": "UtilitiesApplication",
     "operatingSystem": "Web browser",

--- a/weather/index.html
+++ b/weather/index.html
@@ -317,7 +317,7 @@ async function geocode(city) {
   const res = await fetch(`https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(cleanCity)}&count=5&language=en&format=json`);
   if (!res.ok) throw new Error('Could not reach the location service. Please try again.');
   const data = await res.json();
-  if (!data.results?.length) throw new Error('City not found');
+  if (!data.results?.length) throw new Error('City not found — check the spelling and try another city.');
   const usResult = data.results.find(r => r.country_code === 'US') || data.results[0];
   const r = usResult;
   return { lat:r.latitude, lon:r.longitude, name:r.admin1 ? `${r.name}, ${r.admin1}` : `${r.name}, ${r.country}`, tz:r.timezone };

--- a/weather/index.html
+++ b/weather/index.html
@@ -4,6 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#0b1121">
+<!-- Declare the supported colour scheme to the UA up front. color-scheme is otherwise only set inside the render-blocking inline <style> (:root { color-scheme: dark }), so before that CSS parses the browser doesn't know this is a dark-only page and paints the root canvas/scrollbars with the OS default (a brief light flash). This dashboard has no theme toggle, so "dark" (matching the CSS) is correct. No visual change to the settled page. -->
+<meta name="color-scheme" content="dark">
 <link rel="icon" type="image/x-icon" href="/assets/img/favicon.ico">
 <title>Weather Dashboard — NYC</title>
 <meta name="description" content="A live weather dashboard with current conditions, hourly rain chance, a 5-day forecast, air quality, and sun times. Search any city — defaults to New York, NY.">

--- a/weather/index.html
+++ b/weather/index.html
@@ -369,7 +369,16 @@ async function fetchWeather() {
     const aqi = await aqiPromise;
     render(weather, aqi, geo);
   } catch (err) {
-    document.getElementById('content').innerHTML = `<div class="card" role="alert" style="text-align:center;color:var(--danger);">${err.message}</div>`;
+    // Network-level failures (offline, DNS/CORS block, request aborted) reject fetch() with a
+    // TypeError whose browser-generated message ("Failed to fetch" / "NetworkError when attempting
+    // to fetch resource.") was being shown to the user verbatim — inconsistent with the friendly,
+    // actionable strings the other error paths throw (all plain Errors). Map that case to a
+    // matching connection message; keep showing our own Error messages ("City not found…", etc.)
+    // as-is. Static strings only (no user input echoed), mirroring the geocode-error hardening.
+    const msg = (err instanceof TypeError)
+      ? 'Could not connect — check your internet connection and try again.'
+      : err.message;
+    document.getElementById('content').innerHTML = `<div class="card" role="alert" style="text-align:center;color:var(--danger);">${msg}</div>`;
   }
 }
 

--- a/weather/index.html
+++ b/weather/index.html
@@ -577,6 +577,12 @@ function render(w, aqi, geo) {
         return `<div class="hourly-item">
           <div class="time">${fmtHour(h.time)}</div>
           <div class="icon" aria-hidden="true">${getIcon(h.code, h.isDay)}</div>
+          <!-- The per-hour condition icon above is aria-hidden (decorative emoji), so screen-reader
+               users got only the time + rain %, missing the sky condition that sighted users read
+               from the icon. Add it as a visually-hidden label — mirrors getDesc() already surfaced
+               in the hero (.hero-condition) and 5-day rows (.forecast-desc). Positioned absolute, so
+               no visual/layout change to the strip. -->
+          <span class="visually-hidden">${getDesc(h.code)}, </span>
           <div class="chance" style="color:${popColor}">${pop}%</div>
         </div>`;
       }).join('')}

--- a/weather/index.html
+++ b/weather/index.html
@@ -25,6 +25,11 @@
     "operatingSystem": "Web browser",
     "browserRequirements": "Requires JavaScript",
     "isAccessibleForFree": true,
+    "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+    },
     "author": {
         "@type": "Person",
         "name": "Jacob Heifetz-Licht",


### PR DESCRIPTION
Automated, low-risk improvements to jacobhl.com. Each run makes one small, safe, text-only change. Review the diff and merge when you're happy; nothing here auto-deploys.

### Change log
- **2026-07-03** — `index.html`: removed a redundant no-op `.code-popup` light-mode CSS override that duplicated the base rule's values byte-for-byte. Dead-code cleanup, zero visual change.
- **2026-07-03** — `index.html`: added explicit `width`/`height` + `decoding="async"` to the generated project-favicon image (the only generated image missing intrinsic dimensions). Prevents layout shift; zero visual change.
- **2026-07-03** — `404.html`: added explicit `type="button"` to the theme-toggle button (a bare `<button>` defaults to `submit`). Matches `index.html`; zero visual/behavioral change.
- **2026-07-03** — `index.html`: removed a redundant no-op dark-mode `.clickable-img.bg-removed` rule that re-declared the base rule's `mix-blend-mode: screen` (only light mode needs the `multiply` override). Dead-code cleanup, zero visual change.
- **2026-07-03** — `assets/js/main.js`: null-guarded the theme-toggle DOM access so a missing/renamed toggle can't throw and halt the rest of the script (nav, scroll reveal, contact submit). Defensive; passes `node --check`.
- **2026-07-03** — `index.html`: added a `dns-prefetch` hint for `//formspree.io` so the contact-form POST's DNS lookup isn't on the send critical path. Text-only, zero visual change.
- **2026-07-03** — `assets/js/main.js`: announce contact-form send status to screen readers via a visually-hidden `role="status" aria-live="polite"` region (the disabled submit button drops from the a11y tree, so its "Sending…/Sent!/Error" change went unannounced). Passes `node --check`.
- **2026-07-03** — `index.html`: dropped the now-redundant `aria-live` from the contact submit button (the dedicated `#srStatus` live region already announces send status; keeping it on the disabled button caused a double announcement). Zero visual change.
- **2026-07-03** — `weather/index.html`: added an `image` property to the `WebApplication` JSON-LD so search engines have a thumbnail for rich results (reused the existing OG image). Zero visual/behavioral change.
- **2026-07-04** — `weather/index.html`: made the terse "City not found" geocode error actionable and consistent with the other error strings. Static string, no user input echoed. Passes `node --check`.
- **2026-07-04** — `assets/js/main.js`: guarded the scroll-reveal `IntersectionObserver` behind a feature check so unsupported browsers don't leave reveal content permanently `opacity:0` (and don't halt the rest of the file). Zero change in modern browsers.
- **2026-07-04** — `index.html`: hardened the live-preview modal's "Taking a while" slow-load fallback by building the link via `createElement` + `.href`/`.textContent` instead of interpolating a user-typeable URL into `innerHTML`. Self-XSS hardening; renders identically.
- **2026-07-04** — `index.html`: declared `meta name="color-scheme" content="dark light"` so the UA knows the dark-default scheme before the render-blocking `styles.css` loads (removes a brief light flash). Text-only, no visual change to the settled page.
- **2026-07-04** — `weather/index.html`: declared `meta name="color-scheme" content="dark"` so the UA knows this is a dark-only page before the render-blocking inline CSS loads (removes a brief light flash). Text-only, no visual change.
- **2026-07-04** — `weather/index.html`: show a friendly connection-error message on network failure (e.g. offline) instead of the raw "Failed to fetch". Passes `node --check`; zero visual change on success.
- **2026-07-04** — `index.html`: added `aria-haspopup="dialog"` to the live project thumbnails so screen readers announce that activating them opens a dialog preview rather than navigating. Zero visual change.
- **2026-07-04** — `index.html`: added the missing **TidyTab** entry to the no-JS project fallback list so the `<noscript>` mirrors the live projects array. Zero visual change for JS users.
- **2026-07-04** — `weather/index.html`: added `offers` (free) to the `WebApplication` JSON-LD so the free-app declaration is complete for structured-data/rich-result eligibility. JSON-LD still parses; zero visual change.
- **2026-07-04** — `index.html`: gave the live-preview dialog a per-site accessible name so screen-reader users hear which project the preview is showing. Zero visual change.
- **2026-07-04** — `404.html`: declared `meta name="color-scheme" content="dark light"` so the UA knows the dark-default scheme before render-blocking `styles.css` loads (removes a brief light flash); mirrors `index.html`. Text-only, no visual change.
- **2026-07-04** — `light/index.html`: declared `meta name="color-scheme" content="light"` so OS-dark browsers don't flash a dark canvas during the redirect; completes the site-wide color-scheme pattern. Text-only, no visual change.
- **2026-07-04** — `weather/index.html`: gave screen-reader users the per-hour sky condition in the hourly rain-chance strip. The condition emoji is `aria-hidden`, so SR users got only time + rain % while sighted users read the sky state from the icon; added a visually-hidden `getDesc()` label (mirrors the hero `.hero-condition` and 5-day `.forecast-desc`). Positioned absolute — no visual/layout change.