### PR TITLE
Auto-improvements (staging)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<!-- lang="en-US" (not the broader "en") to match the region-specific locale this page already declares everywhere else: og:locale=en_US and the JSON-LD WebSite/ProfilePage inLanguage=en-US. A more specific, valid BCP-47 tag gives assistive tech the correct US-English pronunciation/voice and search engines one consistent language signal. No visual change. -->
+<html lang="en-US" data-theme="dark">
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,12 +2,12 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
         <loc>https://jacobhl.com/</loc>
-        <lastmod>2026-07-04</lastmod>
+        <lastmod>2026-07-05</lastmod>
         <priority>1.0</priority>
     </url>
     <url>
         <loc>https://jacobhl.com/weather/</loc>
-        <lastmod>2026-07-04</lastmod>
+        <lastmod>2026-07-05</lastmod>
         <priority>0.6</priority>
     </url>
 </urlset>


### PR DESCRIPTION
Automated, low-risk improvements to the site — text/HTML/CSS/JS only, no design or media changes. Each run appends one small change below. Preview via the diff (GitHub Pages doesn&#39;t build branch previews). Not for auto-merge — Jacob reviews and merges.

### Run log
- **2026-07-05** — `sitemap.xml`: refresh stale `lastmod` to 2026-07-05. Both indexed URLs (`/` and `/weather/`) had their pages modified on master on 2026-07-05, but the sitemap still advertised 2026-07-04 — an inaccurate freshness signal to crawlers. XML validated; no other change.
- **2026-07-05** — `index.html`: set root `<html lang>` from `en` to the more specific `en-US`. The page already declares region-specific en-US everywhere else (`og:locale=en_US`, JSON-LD `WebSite`/`ProfilePage` `inLanguage=en-US`), so the broad `en` was the odd one out. Aligning it gives assistive tech the correct US-English pronunciation and search engines one consistent language signal. Valid BCP-47 tag; no visual or functional change. (Site-wide pattern — `404.html`/`weather`/`light` still use `en` and can be aligned on later runs.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NMFNho27AxfNNJf7hBDVVR)_