### PR TITLE
Auto-improvements (staging)

### DIFF
--- a/404.html
+++ b/404.html
@@ -31,6 +31,8 @@
         </script>
         <title>Page Not Found — Jacob Heifetz-Licht</title>
         <meta name="description" content="The page you're looking for doesn't exist or has been moved. Head back to jacobhl.com — the portfolio of Jacob Heifetz-Licht, analytics manager and web developer.">
+        <!-- Name the document's author for consistency with the site's other pages (index.html, weather/, and light/ all declare this); the 404 was the only page missing it. Purely document metadata surfaced by some browsers/tools/reader modes; no visual change and no effect on the page's noindex status. -->
+        <meta name="author" content="Jacob Heifetz-Licht">
         <!-- Open Graph / Twitter meta so a shared or mistyped jacobhl.com link (which serves this 404) still gets a branded preview instead of a blank one. og:url is intentionally omitted since this page is served for many different URLs. Mirrors index.html. -->
         <meta property="og:title" content="Page Not Found — Jacob Heifetz-Licht">
         <meta property="og:description" content="This page doesn't exist or has been moved. Head back to jacobhl.com — the portfolio of Jacob Heifetz-Licht, analytics manager and web developer.">

--- a/404.html
+++ b/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="en-US" data-theme="dark">
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 Responsive portfolio site built with HTML, CSS, and JavaScript.  
 Mobile-first design with dark/light theming, smooth scrolling, and interactive elements.
 
-**[jacobhl.com](https://www.jacobhl.com)**
+**[jacobhl.com](https://jacobhl.com)**

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1264,6 +1264,16 @@ html.theme-switching * {
   .proj-cue, .proj-zoom {
     display: none !important;
   }
+  /* Each project's full write-up lives in a detail panel that's collapsed to zero
+     height on screen (grid-template-rows:0fr, revealed by the chevron), and the
+     whole "Private projects" list is collapsed the same way — so a recruiter saving
+     this page as a PDF would otherwise get only the one-line summaries, with the
+     private projects missing entirely. Expand both on paper so the printed PDF
+     carries every project's complete description, and drop the now-purposeless
+     expand/collapse controls (on-screen-only chrome, like the nav/toggles above). */
+  .proj-detail, .more-wrap { grid-template-rows: 1fr !important; }
+  .proj-detail-in, .more-inner { overflow: visible !important; }
+  .proj-chev, .more-toggle { display: none !important; }
   a {
     color: #000 !important;
     text-decoration: underline;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -398,6 +398,12 @@ html.projects-only #nav-toggle {
 
 html {
   scroll-behavior: smooth;
+  /* Offset in-page anchor jumps by the fixed header's height so a clicked nav
+     link (#about, #skills, #contact, …) lands the section heading just below the
+     bar instead of scrolled up behind it. .l-header is position:fixed and its
+     .nav is --header-height tall here (the mobile bar); the desktop bar is taller,
+     overridden in the ≥768px block. No visual change until an anchor is followed. */
+  scroll-padding-top: var(--header-height);
 }
 
 body {
@@ -1159,6 +1165,11 @@ html.theme-switching * {
   }
   .nav {
     height: calc(var(--header-height) + 1.5rem);
+  }
+  /* Match scroll-padding-top to the taller desktop header (the .nav height above)
+     so anchor-linked section headings clear the fixed bar at this breakpoint too. */
+  html {
+    scroll-padding-top: calc(var(--header-height) + 1.5rem);
   }
   .nav__list {
     display: flex;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -18,6 +18,16 @@ const showMenu = (toggleId, navId) =>{
                 toggleMenu()
             }
         })
+        // Escape closes the open menu and returns focus to the toggle (disclosure-widget
+        // convention), so a keyboard/mobile user who opened it can dismiss without tabbing
+        // through every link. No-op when the menu is closed. Mirrors the preview modal's Esc-to-close.
+        document.addEventListener('keydown', (e)=>{
+            if(e.key === 'Escape' && nav.classList.contains('show')){
+                nav.classList.remove('show')
+                toggle.setAttribute('aria-expanded', 'false')
+                toggle.focus()
+            }
+        })
     }
 }
 showMenu('nav-toggle','nav-menu')

--- a/index.html
+++ b/index.html
@@ -866,7 +866,7 @@
                             <li><a href="https://subwaytimes.com" target="_blank" rel="noopener noreferrer">Subway Times</a> — Real-time NYC subway arrivals, faster than Maps.</li>
                             <li><a href="https://davidlicht.com" target="_blank" rel="noopener noreferrer">David Licht</a> — A showcase site for my dad — five decades of drumming.</li>
                             <li><a href="https://theisland.nyc" target="_blank" rel="noopener noreferrer">The Island</a> — Everything happening on NYC's Roosevelt Island, in one place.</li>
-                            <li><a href="https://github.com/jacobhl3ca/safari-pinned-tab-automation" target="_blank" rel="noopener noreferrer">TidyTab</a> — Bulk unpin or close Safari pinned tabs, a macOS menu-bar app.</li>
+                            <li><a href="https://github.com/jacobhl3ca/safari-pinned-tab-automation" target="_blank" rel="noopener noreferrer">TidyTab</a> — Bulk unpin or close Safari pinned tabs — a macOS menu-bar app.</li>
                         </ul>
                     </noscript>
 

--- a/index.html
+++ b/index.html
@@ -1329,7 +1329,12 @@ document.getElementById('urlForm').addEventListener('submit', e=>{
   navigate(u, true); mUrl.blur();   // typed/searched URL records history → back button appears
 });
 modal.addEventListener('click', e=>{ if(e.target===modal) closeModal(); });
-document.addEventListener('keydown', e=>{ if(e.key==='Escape'){ if(modal.classList.contains('fullscreen')) setFullscreen(false); else closeModal(); } });
+// Guard on modal.open: this global Esc handler otherwise ran closeModal() on EVERY Escape
+// press, even with no preview open. closeModal() ends with `sourceThumb.focus()`, and
+// sourceThumb keeps referencing the last-previewed thumbnail after close — so once a user had
+// opened+closed a preview, pressing Esc anywhere (e.g. while typing in the contact form) yanked
+// focus back to that project thumbnail and scrolled it into view. Only act while a preview is open.
+document.addEventListener('keydown', e=>{ if(e.key==='Escape' && modal.classList.contains('open')){ if(modal.classList.contains('fullscreen')) setFullscreen(false); else closeModal(); } });
 // Esc-while-inside-the-preview fix: once the user clicks into the cross-origin iframe,
 // keystrokes go to that frame and never reach the parent's Esc handler above. We can't
 // read keys across origins, so instead we RECLAIM keyboard focus to the dialog the moment

--- a/index.html
+++ b/index.html
@@ -43,7 +43,8 @@
         <meta name="description" content="Data analytics leader and web developer specializing in Python, SQL, Tableau, React, and Next.js. Turning data into things people actually use.">
         <meta name="keywords" content="analytics manager, data analytics, Python, SQL, Tableau, automation, dashboard design, data visualization, ETL, BigQuery, JavaScript, React, Node.js, Next.js, web development">
         <meta name="author" content="Jacob Heifetz-Licht">
-        <meta name="robots" content="index, follow, max-image-preview:large">
+        <!-- max-snippet:-1 explicitly lets Google use a text snippet of any length in results (the default is a search-engine-chosen limit) so the description/intro can show in full; completes the max-* preview directive set alongside the max-image-preview:large already declared. No visual change. -->
+        <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
         <!-- Open Graph meta tags for link previews -->
         <meta property="og:title" content="Jacob Heifetz-Licht — Analytics Manager">
         <!-- <meta property="og:title" content="Jacob Heifetz-Licht — Analytics Engineer"> -->

--- a/index.html
+++ b/index.html
@@ -1081,7 +1081,8 @@
       </div>
       <button type="button" class="nav-btn" id="navBack" title="Back" aria-label="Back" style="display:none;"><i class='bx bx-chevron-left' aria-hidden="true"></i></button>
       <button type="button" class="nav-btn" id="navReload" title="Reload" aria-label="Reload"><i class='bx bx-revision' aria-hidden="true"></i></button>
-      <form class="url-form" id="urlForm"><input class="modal-url" id="modalUrl" type="text" spellcheck="false" autocomplete="off" aria-label="Preview address"></form>
+      <!-- Mobile-input hints for the editable preview address bar, mirroring the contact fields: inputmode="url" gives mobile users the URL-optimized keyboard (dedicated "/", ".", and ".com" keys) instead of the plain text one, autocapitalize="off" stops the first character of an address being capitalized as it's typed, and autocorrect="off" stops iOS "correcting" a URL mid-entry. type stays "text" (not "url") because the submit handler prepends https:// to a bare domain, which native type="url" validation would otherwise reject. All editable hints, no visual change on desktop. -->
+      <form class="url-form" id="urlForm"><input class="modal-url" id="modalUrl" type="text" inputmode="url" spellcheck="false" autocomplete="off" autocapitalize="off" autocorrect="off" aria-label="Preview address"></form>
       <a class="openext" id="modalOpen" target="_blank" rel="noopener" title="Open in new tab" aria-label="Open preview in new tab"><i class='bx bx-link-external' aria-hidden="true"></i></a>
       <button type="button" class="mclose" id="modalClose" title="Close" aria-label="Close preview"><i class='bx bx-x' aria-hidden="true"></i></button>
     </div>

--- a/index.html
+++ b/index.html
@@ -1162,7 +1162,7 @@ function ctaHTML(p){
     const _fav = USE_FAVICONS && FAVICONS[_d];
     const _inner = _fav ? `<img class="favicon" src="${_fav}" alt="" width="20" height="20" loading="lazy" decoding="async">` : `<i class='bx bx-globe' aria-hidden="true"></i>`;
     h+=`<a href="${p.site}" target="_blank" rel="noopener" class="site-link" title="Visit website" aria-label="Visit the ${p.title} website">${_inner}</a>`; }
-  if(p.appstore) h+=`<a href="${p.appstore}" target="_blank" rel="noopener" class="app-store-badge-link" aria-label="Download ${p.title} on the App Store"><img src="assets/img/app-store-badge.svg" alt="" class="app-store-badge" width="120" height="40" decoding="async"></a>`;
+  if(p.appstore) h+=`<a href="${p.appstore}" target="_blank" rel="noopener" class="app-store-badge-link" aria-label="Download ${p.title} on the App Store"><img src="assets/img/app-store-badge.svg" alt="" class="app-store-badge" width="120" height="40" loading="lazy" decoding="async"></a>`;
   if(p.download) h+=`<a href="${p.download}" class="mac-badge" title="Download TidyTab for macOS (.dmg, notarized)"><i class='bx bxl-apple' aria-hidden="true"></i><span class="mb-txt"><span class="mb-top">Download for</span><span class="mb-big">Mac</span></span></a>`;
   if(p.mas) h+=`<a href="${p.mas}" class="mac-badge mas-badge" title="Download on the Mac App Store"><i class='bx bxl-apple' aria-hidden="true"></i><span class="mb-txt"><span class="mb-top">Download on the</span><span class="mb-big">Mac App Store</span></span></a>`;
   if(p.github) h+=`<a href="${p.github}" target="_blank" rel="noopener" class="gh-link" aria-label="View the ${p.title} source on GitHub"><i class='bx bxl-github' aria-hidden="true"></i>GitHub</a>`;

--- a/index_with_animation.html
+++ b/index_with_animation.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<!-- lang="en-US" (not the broader "en") to match the region-specific locale the rest of the site declares (index.html, 404.html, light/, weather/ all use en-US, as does og:locale=en_US). A more specific, valid BCP-47 tag gives assistive tech the correct US-English pronunciation/voice and search engines one consistent language signal. No visual change. -->
+<html lang="en-US" data-theme="dark">
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/light/index.html
+++ b/light/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/weather/index.html
+++ b/weather/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/weather/index.html
+++ b/weather/index.html
@@ -10,7 +10,8 @@
 <title>Weather Dashboard — NYC</title>
 <meta name="description" content="A live weather dashboard with current conditions, hourly rain chance, a 5-day forecast, air quality, and sun times. Search any city — defaults to New York, NY.">
 <meta name="author" content="Jacob Heifetz-Licht">
-<meta name="robots" content="index, follow, max-image-preview:large">
+<!-- max-snippet:-1 explicitly lets Google use a text snippet of any length in results (the default is a search-engine-chosen limit) so the dashboard's description can show in full; completes the max-* preview directive set alongside max-image-preview:large. Mirrors index.html, the site's only other indexed page. No visual change. -->
+<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
 <link rel="canonical" href="https://jacobhl.com/weather/">
 <!-- Structured data so search engines understand this is a free, browser-based weather app. Tie this sub-page's node into the site's linked-data graph the same way the homepage's ProfilePage does: isPartOf the WebSite (#website, defined on index.html) and authored by the Person (#person) — a cross-page @id reference search engines merge site-wide (the author @id already relies on this). inLanguage matches the en-US the homepage's WebSite/ProfilePage nodes declare. Pure metadata, no visual change. -->
 <script type="application/ld+json">


### PR DESCRIPTION
Automated small, safe improvements to the site. One change per run, design preserved, text-only. Review the diff before merging. Do not auto-merge.

### Checklist
- [x] `404.html`: set the root `lang` attribute to `en-US` to match the page&#39;s declared `og:locale` (`en_US`), mirroring index.html. Completes the site-wide `lang` consistency pattern. No visual change.
- [x] `light/index.html`: set the root `lang` attribute to `en-US` to match the page&#39;s declared `og:locale` (`en_US`), mirroring index.html and 404.html. No visual change.
- [x] `weather/index.html`: set the root `lang` attribute to `en-US` to match the page&#39;s declared `og:locale` (`en_US`), `inLanguage` (`en-US`), and JS `en-US` locale. Completes the site-wide `lang` consistency pattern across all pages. No visual change.
- [x] `index.html`: add `max-snippet:-1` to the `robots` meta so Google may use a full-length text snippet in results (default is a search-engine-chosen limit), completing the `max-*` preview directive set alongside the existing `max-image-preview:large`. No visual change.
- [x] `index.html`: align the no-JS project fallback text with the rendered project card (TidyTab em-dash), so crawlers/no-JS visitors see the same copy. No visual change.
- [x] `weather/index.html`: add `max-snippet:-1` to the `robots` meta so Google may use a full-length text snippet in results, mirroring the same change on index.html (the site&#39;s only other indexed page) and completing the `max-*` preview directive set. No visual change.
- [x] `index.html`: add `inputmode=&#34;url&#34;` + `autocapitalize=&#34;off&#34;` + `autocorrect=&#34;off&#34;` to the editable live-preview address bar (`#modalUrl`), mirroring the contact fields&#39; mobile-input hints — mobile users get the URL-optimized keyboard and addresses aren&#39;t capitalized/corrected mid-entry. `type` stays `text` so the submit handler&#39;s bare-domain `https://` prefixing still works. No visual change on desktop.
- [x] `assets/js/main.js`: close the mobile nav menu on **Escape** and return focus to the toggle — the standard disclosure-widget convention, mirroring the live-preview modal&#39;s existing Esc-to-close. The menu already synced `aria-expanded` and closed on link-click, but Escape did nothing. Active only while the menu is open; benefits index.html and 404.html (shared main.js). No visual change.
- [x] `assets/css/styles.css`: expand the collapsed project detail panels and the &#34;Private projects&#34; list inside the `@media print` block. That block was added for the recruiter save-as-PDF case, but each project&#39;s full write-up sits in a panel collapsed to zero height on screen (`grid-template-rows:0fr`) and the private-projects list is collapsed the same way — so a printed PDF carried only the one-line summaries and omitted the private projects entirely. Now both expand on paper (full descriptions included) and the purposeless expand/collapse controls are hidden. Print-media only; no change to the on-screen site.
- [x] `404.html`: add author metadata to complete the site-wide author-metadata pattern — index.html, weather/, and light/ all declare it; the 404 was the only page missing it. Purely document metadata (no SEO effect on this noindex page, no visual change).
- [x] `index.html`: **bug fix** — guard the live-preview modal&#39;s global Escape keydown handler on `modal.classList.contains(&#39;open&#39;)`. It previously ran `closeModal()` on every Escape press, and `closeModal()` ends with `sourceThumb.focus()` where `sourceThumb` keeps referencing the last-previewed thumbnail after close — so once a user had opened and closed a preview, pressing Escape anywhere (e.g. while typing in the contact form) stole focus back to that project thumbnail and scrolled it into view. Now a no-op when no preview is open. No visual change.
- [x] `README.md`: point the site link at the canonical apex URL (`https://jacobhl.com`, dropping the `www.` prefix). The whole site canonicalizes to the bare apex — the `CNAME` file is `jacobhl.com`, and the canonical link, every `og:url`/JSON-LD `@id`, and the sitemap all use `https://jacobhl.com`. The README was the only place linking to the non-canonical `www.` host, which the repo declares no subdomain for. Aligns the repo&#39;s front-page link with the site&#39;s own canonical URL.
- [x] `assets/css/styles.css`: **bug fix** — add `scroll-padding-top` on `html` (matching the fixed header&#39;s height at each breakpoint: `--header-height`/3rem on mobile, `calc(--header-height + 1.5rem)`/4.5rem on desktop ≥768px) so following an in-page nav anchor (`#about`, `#skills`, `#contact`, `#Projects`) lands the target section&#39;s heading just below the fixed header instead of scrolled up behind it. `.l-header` is `position:fixed`, `html` has `scroll-behavior: smooth`, and the nav links use native fragment navigation with no `preventDefault`, so previously the clicked section&#39;s top was hidden under the bar. CSS-only, no effect until an anchor is followed.
- [x] `index_with_animation.html`: set the root `lang` attribute to `en-US` to match the site-wide locale — every other page (index.html, 404.html, light/, weather/) already declares `en-US`, as does `og:locale=en_US`. This orphan/alternate page (served live by GitHub Pages, `noindex`) was the sole remaining `lang=&#34;en&#34;` outlier. Gives assistive tech the correct US-English voice; no visual change.
- [x] `index.html`: add `loading=&#34;lazy&#34;` to the App Store badge `<img>` in the project-card CTA row (`ctaHTML`). The sibling favicon `<img>` in the same row already lazy-loads, but the badge didn&#39;t — so the App Store badges on the below-the-fold project cards (Tonight NYC, The Island) fetched eagerly during initial load. Now they defer until near-viewport, matching the favicon img. The first card (HideScore) is above the fold, so its badge stays in-viewport and loads immediately regardless — no regression. No visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9e6dQi6L4pqYjd4Q3WTDf